### PR TITLE
fix: critical workflow errors — injection, jq compat, SHA pinning, permissions

### DIFF
--- a/.github/workflows/health-ci-daily.yml
+++ b/.github/workflows/health-ci-daily.yml
@@ -26,7 +26,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Install yq
         shell: bash
@@ -209,7 +209,7 @@ jobs:
       result: ${{ steps.ai.outputs.result }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: AI synthesis
         id: ai
@@ -233,14 +233,14 @@ jobs:
           egress-policy: audit
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Write report
         shell: bash
+        env:
+          REPORT: ${{ needs.synthesize.outputs.result }}
         run: |
-          cat > /tmp/daily-report.md << 'REPORT_EOF'
-          ${{ needs.synthesize.outputs.result }}
-          REPORT_EOF
+          printf '%s' "$REPORT" > /tmp/daily-report.md
 
       - name: Set date
         id: date
@@ -257,8 +257,10 @@ jobs:
       - name: Post Slack report
         continue-on-error: true
         uses: ./actions/observability/publishers/post-slack-report
+        env:
+          REPORT_MSG: ${{ needs.synthesize.outputs.result }}
         with:
           webhook-url: ${{ secrets.SLACK_CI_WEBHOOK }}
           title: "CI Health Report - ${{ steps.date.outputs.today }}"
-          message: ${{ needs.synthesize.outputs.result }}
+          message: ${{ env.REPORT_MSG }}
           status: info

--- a/.github/workflows/health-ci-weekly.yml
+++ b/.github/workflows/health-ci-weekly.yml
@@ -26,7 +26,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Install yq
         shell: bash
@@ -165,7 +165,7 @@ jobs:
       result: ${{ steps.ai.outputs.result }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: AI synthesis
         id: ai
@@ -189,14 +189,14 @@ jobs:
           egress-policy: audit
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Write report
         shell: bash
+        env:
+          REPORT: ${{ needs.synthesize.outputs.result }}
         run: |
-          cat > /tmp/weekly-report.md << 'REPORT_EOF'
-          ${{ needs.synthesize.outputs.result }}
-          REPORT_EOF
+          printf '%s' "$REPORT" > /tmp/weekly-report.md
 
       - name: Set date
         id: date
@@ -213,8 +213,10 @@ jobs:
       - name: Post Slack report
         continue-on-error: true
         uses: ./actions/observability/publishers/post-slack-report
+        env:
+          REPORT_MSG: ${{ needs.synthesize.outputs.result }}
         with:
           webhook-url: ${{ secrets.SLACK_CI_WEBHOOK }}
           title: "CI Weekly Deep Dive - ${{ steps.date.outputs.week }}"
-          message: ${{ needs.synthesize.outputs.result }}
+          message: ${{ env.REPORT_MSG }}
           status: info

--- a/.github/workflows/heartbeat.yml
+++ b/.github/workflows/heartbeat.yml
@@ -23,7 +23,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: "Probe: triage-failure last success"
         id: probe-triage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Run tests
         shell: bash
@@ -43,7 +43,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Validate action structure
         shell: bash
@@ -78,7 +78,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Validate workflow structure
         shell: bash

--- a/.github/workflows/triage-failure.yml
+++ b/.github/workflows/triage-failure.yml
@@ -31,7 +31,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Install yq
         shell: bash
@@ -86,11 +86,12 @@ jobs:
     permissions:
       contents: write
       issues: write
+      pull-requests: write
     strategy:
       max-parallel: 3
       fail-fast: false
       matrix:
-        run: ${{ fromJson(needs.scan.outputs.runs) }}
+        run: ${{ fromJson(needs.scan.outputs.runs)[0:10] }}
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40
@@ -98,7 +99,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Fetch _state branch
         shell: bash
@@ -371,10 +372,12 @@ jobs:
           PATTERN_ID="ai-$(echo -n "$PATTERN" | md5sum | cut -c1-8)"
 
           # Create pattern JSON
+          TODAY=$(date -u +%Y-%m-%d)
           jq -n \
             --arg id "$PATTERN_ID" \
             --arg match "$PATTERN" \
             --arg category "$CATEGORY" \
+            --arg today "$TODAY" \
             '{
               id: $id,
               match: $match,
@@ -383,7 +386,7 @@ jobs:
               notify: (if $category == "flaky" then false else true end),
               severity: (if $category == "flaky" then "low" elif $category == "security" then "high" else "medium" end),
               seen_count: 1,
-              last_seen: (now | strftime("%Y-%m-%d")),
+              last_seen: $today,
               source: "ai-learned"
             }' > /tmp/new-pattern.json
 

--- a/actions/observability/publishers/slack-notify/action.yml
+++ b/actions/observability/publishers/slack-notify/action.yml
@@ -66,12 +66,14 @@ runs:
         esac
 
         # Build Slack payload with Block Kit
+        TIMESTAMP=$(date -u +"%Y-%m-%d %H:%M:%S UTC")
         PAYLOAD=$(jq -n \
           --arg emoji "$EMOJI" \
           --arg title "$TITLE" \
           --arg message "$MESSAGE" \
           --arg color "$COLOR" \
           --arg channel "$CHANNEL" \
+          --arg timestamp "$TIMESTAMP" \
           '{
             blocks: [
               {
@@ -94,7 +96,7 @@ runs:
                 elements: [
                   {
                     type: "mrkdwn",
-                    text: "_EvolveCI | \(now | strftime("%Y-%m-%d %H:%M:%S UTC"))_"
+                    text: "_EvolveCI | \($timestamp)_"
                   }
                 ]
               }


### PR DESCRIPTION
## Summary

6 files changed, 6 categories of fixes:

### 🔴 Security fixes
- **Shell injection**: AI output was directly interpolated into heredoc and Slack message fields. Replaced with `env:` variable passing to prevent arbitrary code execution.
- **SHA pinning**: All `actions/checkout@v4` pinned to SHA `34e114876b0b11c390a56381ad16ebd13914f8d5` per manifest.yml

### 🟡 Bug fixes
- **jq compatibility**: `now | strftime()` removed from slack-notify and triage-failure (not portable across jq versions). Replaced with bash `date` + `--arg`.
- **Missing permissions**: Added `pull-requests: write` to triage job (needed for 'Learn new pattern' PR creation step)
- **Matrix unbounded**: Triage matrix now limited to top 10 runs via `[0:10]` slice

### Files changed
| File | Changes |
|------|---------|
| `health-ci-daily.yml` | SHA pin, injection fix in report + Slack |
| `health-ci-weekly.yml` | SHA pin, injection fix in report + Slack |
| `triage-failure.yml` | SHA pin, permissions, matrix limit, jq fix |
| `heartbeat.yml` | SHA pin |
| `test.yml` | SHA pin |
| `slack-notify/action.yml` | jq `now\|strftime` → bash date

## Test plan
- [ ] `test.yml` workflow passes (validate-actions + validate-workflows + bats tests)
- [ ] `heartbeat.yml` workflow passes
- [ ] Manual trigger of `triage-failure.yml` (needs secrets)
- [ ] Manual trigger of `health-ci-daily.yml` (needs secrets)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/YiAgent/codesmith/EvolveCI/pr/1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned GitHub Actions dependencies to specific commit versions across all workflows for improved security and stability.
  * Enhanced report handling and Slack notification delivery with improved timestamp standardization.
  * Optimized triage job performance by limiting batch processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->