### PR TITLE
feat: wire up state layer, circuit breaker, flakiness + trend computation

### DIFF
--- a/.github/workflows/health-ci-daily.yml
+++ b/.github/workflows/health-ci-daily.yml
@@ -77,11 +77,20 @@ jobs:
           echo "$stats" >> "$GITHUB_OUTPUT"
           echo "EVOLVECI_EOF" >> "$GITHUB_OUTPUT"
 
+      - name: Read health history
+        id: history
+        uses: ./actions/observability/state/read-state
+        with:
+          key: "workflow-health"
+          state-path: "workflow-health/all.json"
+          default: '{"workflows":{}}'
+
       - name: Detect degradations
         id: degradations
         shell: bash
         run: |
           STATS='${{ steps.stats.outputs.stats }}'
+          HISTORY='${{ steps.history.outputs.value }}'
           TODAY=$(date -u +%Y-%m-%d)
 
           degradations="[]"
@@ -89,17 +98,10 @@ jobs:
           while IFS= read -r wf; do
             key=$(echo "$wf" | jq -r '.key')
             current_rate=$(echo "$wf" | jq -r '.failure_rate')
-            repo=$(echo "$wf" | jq -r '.repo')
-            workflow=$(echo "$wf" | jq -r '.workflow')
 
-            # Read historical health from _state
-            state_path="workflow-health/$(echo "$key" | tr '/' '-').json"
-            git fetch origin _state --depth=1 2>/dev/null || true
-            history=$(git show "origin/_state:$state_path" 2>/dev/null || echo '{"daily":{}}')
-
-            # Calculate 7-day average
-            seven_day_avg=$(echo "$history" | jq -r '
-              .daily // {} |
+            # Calculate 7-day average from history
+            seven_day_avg=$(echo "$HISTORY" | jq -r --arg k "$key" '
+              .workflows[$k].daily // {} |
               to_entries |
               sort_by(.key) |
               .[-7:] |
@@ -121,45 +123,47 @@ jobs:
           echo "$degradations" >> "$GITHUB_OUTPUT"
           echo "EVOLVECI_EOF" >> "$GITHUB_OUTPUT"
 
-      - name: Update health history
+      - name: Build updated health history
+        id: updated-history
         shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           STATS='${{ steps.stats.outputs.stats }}'
+          HISTORY='${{ steps.history.outputs.value }}'
           TODAY=$(date -u +%Y-%m-%d)
 
-          # Checkout _state branch
-          git fetch origin _state --depth=1 2>/dev/null || true
-          git checkout -B _state origin/_state 2>/dev/null || {
-            git checkout --orphan _state
-            git rm -rf . 2>/dev/null || true
-            git -c user.name="evolveCI bot" -c user.email="bot@evolveci.dev" \
-              commit --allow-empty -m "init: CI observability state branch"
-          }
-
-          mkdir -p workflow-health
-
+          # Merge today's rates into history
+          updated="$HISTORY"
           while IFS= read -r wf; do
             key=$(echo "$wf" | jq -r '.key')
             rate=$(echo "$wf" | jq -r '.failure_rate')
-            state_path="workflow-health/$(echo "$key" | tr '/' '-').json"
-
-            # Read existing
-            existing=$(cat "$state_path" 2>/dev/null || echo '{"daily":{}}')
-
-            # Merge today's rate
-            updated=$(echo "$existing" | jq --arg d "$TODAY" --argjson r "$rate" '.daily[$d] = $r')
-            echo "$updated" > "$state_path"
+            updated=$(echo "$updated" | jq \
+              --arg k "$key" \
+              --arg d "$TODAY" \
+              --argjson r "$rate" \
+              '.workflows[$k].daily[$d] = $r')
           done < <(echo "$STATS" | jq -c '.[]')
 
-          # Commit and push
-          git add workflow-health/
-          git -c user.name="evolveCI bot" -c user.email="bot@evolveci.dev" \
-            commit -m "state: update health history $TODAY" || true
-          git push origin _state 2>/dev/null || echo "::warning::Failed to push health history"
+          {
+            echo "history<<EVOLVECI_EOF"
+            echo "$updated"
+            echo "EVOLVECI_EOF"
+          } >> "$GITHUB_OUTPUT"
 
-          git checkout - 2>/dev/null || true
+      - name: Write health history
+        uses: ./actions/observability/state/write-state
+        with:
+          key: "workflow-health"
+          state-path: "workflow-health/all.json"
+          value: ${{ steps.updated-history.outputs.history }}
+          merge: "true"
+
+      - name: Compute trends
+        id: trends
+        uses: ./actions/observability/analyzers/compute-trends
+        with:
+          repo: ${{ github.repository }}
+          current-health-data: ${{ steps.updated-history.outputs.history }}
+          token: ${{ secrets.CROSS_REPO_PAT }}
 
       - name: Aggregate output
         id: aggregate
@@ -184,6 +188,8 @@ jobs:
             --argjson rate "$failure_rate" \
             --argjson workflows "$STATS" \
             --argjson degradations "$DEGRADATIONS" \
+            --arg trend "${{ steps.trends.outputs.trend || 'stable' }}" \
+            --argjson delta "${{ steps.trends.outputs.delta || 0 }}" \
             --arg date "$(date -u +%Y-%m-%d)" \
             '{
               date: $date,
@@ -191,7 +197,9 @@ jobs:
               total_failures: $failures,
               failure_rate: $rate,
               workflows: $workflows,
-              degradations: $degradations
+              degradations: $degradations,
+              trend: $trend,
+              trend_delta: $delta,
             }')
 
           {

--- a/.github/workflows/health-ci-weekly.yml
+++ b/.github/workflows/health-ci-weekly.yml
@@ -83,66 +83,55 @@ jobs:
           echo "$repo_stats" >> "$GITHUB_OUTPUT"
           echo "EVOLVECI_EOF" >> "$GITHUB_OUTPUT"
 
-      - name: Read previous snapshot
-        id: previous
+      - name: Compute week dates
+        id: dates
         shell: bash
         run: |
-          # Get last week's ISO week number
           last_week=$(date -u -d "7 days ago" +%Y-W%V 2>/dev/null || date -u -v-7d +%Y-W%V 2>/dev/null || echo "")
           this_week=$(date -u +%Y-W%V)
-
-          if [ -n "$last_week" ]; then
-            git fetch origin _state --depth=1 2>/dev/null || true
-            previous=$(git show "origin/_state:weekly-snapshots/$last_week.json" 2>/dev/null || echo "{}")
-          else
-            previous="{}"
-          fi
-
           echo "this-week=$this_week" >> "$GITHUB_OUTPUT"
-          echo "previous<<EVOLVECI_EOF" >> "$GITHUB_OUTPUT"
-          echo "$previous" >> "$GITHUB_OUTPUT"
-          echo "EVOLVECI_EOF" >> "$GITHUB_OUTPUT"
+          echo "last-week=$last_week" >> "$GITHUB_OUTPUT"
+          echo "snapshot-path=weekly-snapshots/$this_week.json" >> "$GITHUB_OUTPUT"
+          echo "previous-path=weekly-snapshots/$last_week.json" >> "$GITHUB_OUTPUT"
 
-      - name: Save current snapshot
+      - name: Read previous snapshot
+        id: previous
+        uses: ./actions/observability/state/read-state
+        with:
+          key: "weekly-snapshot:${{ steps.dates.outputs.last-week }}"
+          state-path: ${{ steps.dates.outputs.previous-path }}
+          default: "{}"
+
+      - name: Build current snapshot
+        id: current-snapshot
         shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          THIS_WEEK="${{ steps.previous.outputs.this-week }}"
-          STATS='${{ steps.stats.outputs.repo_stats }}'
-
           snapshot=$(jq -n \
-            --arg week "$THIS_WEEK" \
+            --arg week "${{ steps.dates.outputs.this-week }}" \
             --arg date "$(date -u +%Y-%m-%d)" \
-            --argjson repos "$STATS" \
+            --argjson repos '${{ steps.stats.outputs.repo_stats }}' \
             '{week: $week, date: $date, repos: $repos}')
 
-          echo "$snapshot" > /tmp/weekly-snapshot.json
+          {
+            echo "snapshot<<EVOLVECI_EOF"
+            echo "$snapshot"
+            echo "EVOLVECI_EOF"
+          } >> "$GITHUB_OUTPUT"
 
-          # Write to _state branch
-          git fetch origin _state --depth=1 2>/dev/null || true
-          git checkout -B _state origin/_state 2>/dev/null || {
-            git checkout --orphan _state
-            git rm -rf . 2>/dev/null || true
-            git -c user.name="evolveCI bot" -c user.email="bot@evolveci.dev" \
-              commit --allow-empty -m "init: CI observability state branch"
-          }
-
-          mkdir -p weekly-snapshots
-          echo "$snapshot" > "weekly-snapshots/$THIS_WEEK.json"
-          git add "weekly-snapshots/$THIS_WEEK.json"
-          git -c user.name="evolveCI bot" -c user.email="bot@evolveci.dev" \
-            commit -m "state: add weekly snapshot $THIS_WEEK" || true
-          git push origin _state 2>/dev/null || echo "::warning::Failed to push weekly snapshot"
-
-          git checkout - 2>/dev/null || true
+      - name: Save current snapshot
+        uses: ./actions/observability/state/write-state
+        with:
+          key: "weekly-snapshot:${{ steps.dates.outputs.this-week }}"
+          state-path: ${{ steps.dates.outputs.snapshot-path }}
+          value: ${{ steps.current-snapshot.outputs.snapshot }}
+          merge: "false"
 
       - name: Aggregate output
         id: aggregate
         shell: bash
         run: |
           current=$(jq -n \
-            --arg week "${{ steps.previous.outputs.this-week }}" \
+            --arg week "${{ steps.dates.outputs.this-week }}" \
             --arg date "$(date -u +%Y-%m-%d)" \
             --argjson repos '${{ steps.stats.outputs.repo_stats }}' \
             '{week: $week, date: $date, repos: $repos}')
@@ -151,7 +140,7 @@ jobs:
             echo "weekly-data<<EVOLVECI_EOF"
             jq -n \
               --argjson current "$current" \
-              --argjson previous '${{ steps.previous.outputs.previous }}' \
+              --argjson previous '${{ steps.previous.outputs.value }}' \
               '{current: $current, previous: $previous}'
             echo "EVOLVECI_EOF"
           } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/triage-failure.yml
+++ b/.github/workflows/triage-failure.yml
@@ -146,6 +146,16 @@ jobs:
           log: ${{ steps.redact.outputs.redacted || '' }}
           patterns-path: ${{ steps.patterns.outputs.path }}
 
+      - name: Compute flakiness score
+        id: flakiness
+        if: matrix.run.conclusion == 'failure'
+        uses: ./actions/observability/analyzers/compute-flakiness
+        with:
+          repo: ${{ matrix.run.repo }}
+          workflow-name: ${{ matrix.run.workflowName }}
+          lookback: "20"
+          token: ${{ secrets.CROSS_REPO_PAT }}
+
       - name: Tier 2 - Classify heuristic
         id: tier2
         if: matrix.run.conclusion == 'failure' && steps.tier1.outputs.matched != 'true'
@@ -153,7 +163,7 @@ jobs:
         with:
           log: ${{ steps.redact.outputs.redacted || '' }}
           failed-step: ${{ fromJson(matrix.run.failed_jobs || '[]')[0].steps[0] || '' }}
-          flakiness-score: "0"
+          flakiness-score: ${{ steps.flakiness.outputs.flakiness-score || '0' }}
 
       - name: Tier 3 - Prepare AI context
         id: tier3-prep
@@ -257,40 +267,91 @@ jobs:
           daily-budget: "3"
           token: ${{ secrets.CROSS_REPO_PAT }}
 
+      - name: Read rerun counter
+        id: read-counter
+        if: steps.rerun.outputs.result == 'rerunned'
+        uses: ./actions/observability/state/read-state
+        with:
+          key: "reruns:${{ matrix.run.repo }}/${{ matrix.run.workflowName }}"
+          state-path: "daily-counters/$(date -u +%Y-%m-%d).json"
+          default: '{"reruns":{}}'
+
       - name: Update rerun counter
+        id: update-counter
         if: steps.rerun.outputs.result == 'rerunned'
         shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          COUNTER_KEY="${{ matrix.run.repo }}/${{ matrix.run.workflowName }}/$(date -u +%Y-%m-%d)"
-          NEW_COUNT=$(jq -r '.reruns["'"$COUNTER_KEY"'"] // 0' /tmp/rerun-counter.json 2>/dev/null || echo 1)
-
-          counter_json=$(jq -n --arg k "$COUNTER_KEY" --argjson v "$NEW_COUNT" '{reruns: {($k): $v}}')
-
-          # Dual write: cache + _state branch
-          mkdir -p .state-cache
-          echo "$counter_json" > .state-cache/data.json
-
-          git fetch origin _state --depth=1 2>/dev/null || true
-          git checkout -B _state origin/_state 2>/dev/null || {
-            git checkout --orphan _state
-            git rm -rf . 2>/dev/null || true
-            git -c user.name="evolveCI bot" -c user.email="bot@evolveci.dev" \
-              commit --allow-empty -m "init: CI observability state branch"
-          }
-
-          mkdir -p daily-counters
           TODAY=$(date -u +%Y-%m-%d)
-          existing=$(cat "daily-counters/$TODAY.json" 2>/dev/null || echo '{}')
-          merged=$(echo "$existing" | jq --argjson new "$counter_json" '. * $new')
-          echo "$merged" > "daily-counters/$TODAY.json"
+          COUNTER_KEY="${{ matrix.run.repo }}/${{ matrix.run.workflowName }}/$TODAY"
+          EXISTING='${{ steps.read-counter.outputs.value }}'
+          NEW_COUNT=$(echo "$EXISTING" | jq -r ".reruns[\"$COUNTER_KEY\"] // 0")
+          NEW_COUNT=$((NEW_COUNT + 1))
 
-          git add "daily-counters/$TODAY.json"
-          git -c user.name="evolveCI bot" -c user.email="bot@evolveci.dev" \
-            commit -m "state: update rerun counter" || true
-          git push origin _state 2>/dev/null || echo "::warning::Failed to push counter update"
-          git checkout - 2>/dev/null || true
+          counter_json=$(echo "$EXISTING" | jq \
+            --arg k "$COUNTER_KEY" \
+            --argjson v "$NEW_COUNT" \
+            '.reruns[$k] = $v')
+
+          {
+            echo "counter-json<<EVOLVECI_EOF"
+            echo "$counter_json"
+            echo "EVOLVECI_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Write rerun counter
+        if: steps.rerun.outputs.result == 'rerunned'
+        uses: ./actions/observability/state/write-state
+        with:
+          key: "reruns:${{ matrix.run.repo }}/${{ matrix.run.workflowName }}"
+          state-path: "daily-counters/$(date -u +%Y-%m-%d).json"
+          value: ${{ steps.update-counter.outputs.counter-json }}
+          merge: "true"
+
+      - name: Check circuit breaker budget
+        id: budget-check
+        if: steps.rerun.outputs.result == 'rerunned'
+        shell: bash
+        run: |
+          TODAY=$(date -u +%Y-%m-%d)
+          COUNTER_KEY="${{ matrix.run.repo }}/${{ matrix.run.workflowName }}/$TODAY"
+          EXISTING='${{ steps.update-counter.outputs.counter-json }}'
+          CURRENT=$(echo "$EXISTING" | jq -r ".reruns[\"$COUNTER_KEY\"] // 0")
+
+          # Load budget limits from circuit-config
+          WORKFLOW_LIMIT=$(python3 -c "import yaml; print(yaml.safe_load(open('data/circuit-config.yml'))['dimensions']['workflow']['daily_limit'])")
+          REPO_LIMIT=$(python3 -c "import yaml; print(yaml.safe_load(open('data/circuit-config.yml'))['dimensions']['repo']['daily_limit'])")
+
+          TRIPPED="false"
+          REASON=""
+
+          # Check workflow dimension
+          if [ "$CURRENT" -ge "$WORKFLOW_LIMIT" ]; then
+            TRIPPED="true"
+            REASON="workflow budget: $CURRENT/$WORKFLOW_LIMIT reruns today"
+          fi
+
+          # Check repo dimension (sum all counters for this repo today)
+          REPO_TOTAL=$(echo "$EXISTING" | jq -r "
+            .reruns | to_entries
+              | map(select(.key | startswith(\"${{ matrix.run.repo }}/\")))
+              | map(.value) | add // 0
+          ")
+          if [ "$REPO_TOTAL" -ge "$REPO_LIMIT" ]; then
+            TRIPPED="true"
+            REASON="repo budget: $REPO_TOTAL/$REPO_LIMIT reruns today"
+          fi
+
+          echo "tripped=$TRIPPED" >> "$GITHUB_OUTPUT"
+          echo "reason=$REASON" >> "$GITHUB_OUTPUT"
+
+      - name: Trip circuit breaker
+        if: steps.budget-check.outputs.tripped == 'true'
+        uses: ./actions/observability/publishers/trip-circuit-breaker
+        with:
+          repo: ${{ matrix.run.repo }}
+          workflow-name: ${{ matrix.run.workflowName }}
+          reason: ${{ steps.budget-check.outputs.reason }}
+          dimension: workflow
 
       - name: Create issue
         if: steps.dispatch.outputs.should-notify == 'true' && steps.dispatch.outputs.category != 'flaky'

--- a/manifest.yml
+++ b/manifest.yml
@@ -4,30 +4,6 @@ actions:
     version: v4
     sha: 34e114876b0b11c390a56381ad16ebd13914f8d5
 
-  actions/cache:
-    version: v4
-    sha: 0057852bfaa89a56745cba8c7296529d2fc39830
-
   step-security/harden-runner:
     version: v2
     sha: 8d3c67de8e2fe68ef647c8db1e6a09f647780f40
-
-  peter-evans/create-issue-from-file:
-    version: v6
-    sha: fca9117c27cdc29c6c4db3b86c48e4115a786710
-
-  peter-evans/create-pull-request:
-    version: v7
-    sha: 22a9089034f40e5a961c8808d113e2c98fb63676
-
-  nick-fields/retry:
-    version: v3
-    sha: ce71cc2ab81d554ebbe88c79ab5975992d79ba08
-
-  DeveloperMetrics/deployment-frequency:
-    version: main
-    sha: TBD
-
-  DeveloperMetrics/lead-time-for-changes:
-    version: main
-    sha: TBD


### PR DESCRIPTION
## Summary

Wires up 6 previously orphaned actions into the actual workflows, and cleans up unused manifest entries.

### State Layer (`read-state` / `write-state`)
All inline git operations (fetch _state, checkout, commit, push) replaced with the state layer actions that include retry logic and dual-write (cache + branch).

| Workflow | Before | After |
|----------|--------|-------|
| health-ci-daily | 20+ lines inline git | `read-state` + `write-state` |
| health-ci-weekly | 15+ lines inline git | `read-state` + `write-state` |
| triage-failure | 15+ lines inline git | `read-state` + `write-state` |

### Circuit Breaker (`trip-circuit-breaker`)
- Reads budget limits from `data/circuit-config.yml` (workflow: 3/day, repo: 20/day)
- After each rerun, checks if any dimension is exceeded
- Trips circuit breaker by creating issue with `ci:circuit-broken` label
- Scan job already checks for this label and skips triage when active

### Flakiness Score (`compute-flakiness`)
- Computes 0-100 flakiness score for each failing workflow (last 20 runs)
- Score passed to `classify-heuristic` for better classification accuracy

### Trend Analysis (`compute-trends`)
- Compares recent 7-day vs previous 7-day failure rate average
- Output: improving / stable / degrading + percentage point delta
- Included in daily report output

### Manifest Cleanup
Removed 6 entries that were never referenced: `actions/cache`, `peter-evans/create-issue-from-file`, `peter-evans/create-pull-request`, `nick-fields/retry`, `DeveloperMetrics/deployment-frequency`, `DeveloperMetrics/lead-time-for-changes`

## Test plan
- [x] 42/42 bats tests pass
- [x] All YAML files parse correctly
- [x] `gh workflow run triage-failure.yml` dispatches without error
- [ ] `test.yml` CI passes on PR
- [ ] `triage-failure.yml` succeeds on next scheduled run (or manual trigger)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/YiAgent/codesmith/EvolveCI/pr/2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added trend tracking and trend delta metrics to health monitoring reports.
  * Implemented flakiness-based scoring for improved failure classification accuracy.

* **Chores**
  * Refactored CI/CD workflows to use centralized state management.
  * Removed obsolete GitHub Actions dependencies from configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->