### PR TITLE
feat(agents): route via OpenCI claude-harness using GLM Coding Plan

### DIFF
--- a/.github/workflows/agent-daily.yml
+++ b/.github/workflows/agent-daily.yml
@@ -24,12 +24,12 @@ jobs:
     with:
       task: "daily-report"
       prompt: "/daily-report"
-      model: ${{ vars.CLAUDE_MODEL || 'claude-sonnet-4-6' }}
+      model: ${{ vars.CLAUDE_MODEL || 'glm-5.1' }}
       api-provider: "anthropic"
       max-turns: 20
       timeout-minutes: 15
     secrets:
-      api-key: ${{ secrets.ANTHROPIC_API_KEY }}
-      api-base-url: ${{ secrets.ANTHROPIC_BASE_URL }}
+      api-key: ${{ secrets.GLM_API_KEY }}
+      api-base-url: ${{ secrets.GLM_BASE_URL || 'https://open.bigmodel.cn/api/anthropic' }}
       github-token: ${{ secrets.CROSS_REPO_PAT }}
       slack-webhook: ${{ secrets.SLACK_CI_WEBHOOK }}

--- a/.github/workflows/agent-heartbeat.yml
+++ b/.github/workflows/agent-heartbeat.yml
@@ -25,12 +25,12 @@ jobs:
     with:
       task: "heartbeat"
       prompt: "/heartbeat"
-      model: ${{ vars.CLAUDE_MODEL || 'claude-sonnet-4-6' }}
+      model: ${{ vars.CLAUDE_MODEL || 'glm-5.1' }}
       api-provider: "anthropic"
       max-turns: 15
       timeout-minutes: 10
     secrets:
-      api-key: ${{ secrets.ANTHROPIC_API_KEY }}
-      api-base-url: ${{ secrets.ANTHROPIC_BASE_URL }}
+      api-key: ${{ secrets.GLM_API_KEY }}
+      api-base-url: ${{ secrets.GLM_BASE_URL || 'https://open.bigmodel.cn/api/anthropic' }}
       github-token: ${{ secrets.GITHUB_TOKEN }}
       slack-webhook: ${{ secrets.SLACK_CI_WEBHOOK }}

--- a/.github/workflows/agent-triage.yml
+++ b/.github/workflows/agent-triage.yml
@@ -30,12 +30,14 @@ jobs:
     with:
       task: "triage"
       prompt: ${{ inputs.prompt || '/triage' }}
-      model: ${{ vars.CLAUDE_MODEL || 'claude-sonnet-4-6' }}
+      model: ${{ vars.CLAUDE_MODEL || 'glm-5.1' }}
       api-provider: "anthropic"
       max-turns: 30
       timeout-minutes: 20
+      # Triage needs to execute the log-redaction script.
+      extra-allowed-tools: "Bash(bash lib/redact-log.sh),Bash(bash lib/),Bash(cut),Bash(tr)"
     secrets:
-      api-key: ${{ secrets.ANTHROPIC_API_KEY }}
-      api-base-url: ${{ secrets.ANTHROPIC_BASE_URL }}
+      api-key: ${{ secrets.GLM_API_KEY }}
+      api-base-url: ${{ secrets.GLM_BASE_URL || 'https://open.bigmodel.cn/api/anthropic' }}
       github-token: ${{ secrets.CROSS_REPO_PAT }}
       slack-webhook: ${{ secrets.SLACK_CI_WEBHOOK }}

--- a/.github/workflows/agent-weekly.yml
+++ b/.github/workflows/agent-weekly.yml
@@ -24,12 +24,12 @@ jobs:
     with:
       task: "weekly-report"
       prompt: "/weekly-report"
-      model: ${{ vars.CLAUDE_MODEL || 'claude-sonnet-4-6' }}
+      model: ${{ vars.CLAUDE_MODEL || 'glm-5.1' }}
       api-provider: "anthropic"
       max-turns: 25
       timeout-minutes: 25
     secrets:
-      api-key: ${{ secrets.ANTHROPIC_API_KEY }}
-      api-base-url: ${{ secrets.ANTHROPIC_BASE_URL }}
+      api-key: ${{ secrets.GLM_API_KEY }}
+      api-base-url: ${{ secrets.GLM_BASE_URL || 'https://open.bigmodel.cn/api/anthropic' }}
       github-token: ${{ secrets.CROSS_REPO_PAT }}
       slack-webhook: ${{ secrets.SLACK_CI_WEBHOOK }}


### PR DESCRIPTION
## Summary

Wire the four agent workflows (heartbeat / daily / weekly / triage) to the refactored OpenCI claude-harness, using **GLM Coding Plan** (Zhipu BigModel) as the LLM backend through the Anthropic-compatible endpoint.

- Endpoint: \`https://open.bigmodel.cn/api/anthropic\`
- Default model: \`glm-5.1\`
- Auth: \`secrets.GLM_API_KEY\` (org-level)
- The harness mirrors api-key into \`ANTHROPIC_AUTH_TOKEN\` automatically, so Z.AI/Zhipu's Bearer auth works with no caller-side wiring (see https://github.com/YiAgent/OpenCI/pull/1).

## Depends on

- https://github.com/YiAgent/OpenCI/pull/1 — must merge first (the workflows reference \`YiAgent/OpenCI/.github/workflows/claude-harness.yml@main\`).

## Per-workflow notes

- **heartbeat** (every 6h): default \`GITHUB_TOKEN\`, slack optional.
- **daily-report** (workdays UTC 01:00): uses \`CROSS_REPO_PAT\` for cross-repo CI queries.
- **weekly-report** (Mon UTC 02:00): same as daily, more turns.
- **triage** (every 15min): adds \`extra-allowed-tools\` for \`bash lib/redact-log.sh\` so log redaction works inside Claude.

## Test plan

- [x] \`actionlint\` clean on all four files
- [ ] After OpenCI#1 merges, manually \`gh workflow run agent-heartbeat.yml\` as smoke test
- [ ] Confirm Slack/Issue side-effects fire correctly when an alert condition is met

## Required org-level config

Already present:
- \`secrets.GLM_API_KEY\` ✓

Optional:
- \`secrets.GLM_BASE_URL\` (falls back to literal \`open.bigmodel.cn\` URL if missing)
- \`secrets.SLACK_CI_WEBHOOK\` (alerts will be silent if missing — workflows still run)
- \`secrets.CROSS_REPO_PAT\` (daily/weekly/triage need this for cross-repo CI access; heartbeat just needs default \`GITHUB_TOKEN\`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/YiAgent/codesmith/EvolveCI/pr/6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configurations to use new model and API provider settings across multiple automated processes, including daily monitoring, heartbeat checks, issue triage, and weekly runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->