### PR TITLE
fix(agents): raise max-turns budget for daily / weekly reports

### DIFF
--- a/.github/workflows/agent-daily.yml
+++ b/.github/workflows/agent-daily.yml
@@ -29,8 +29,8 @@ jobs:
       prompt: "/daily-report"
       model: ${{ vars.CLAUDE_MODEL || 'glm-5.1' }}
       api-provider: "anthropic"
-      max-turns: 20
-      timeout-minutes: 15
+      max-turns: 40
+      timeout-minutes: 25
     secrets:
       api-key: ${{ secrets.GLM_API_KEY }}
       api-base-url: ${{ secrets.GLM_BASE_URL || 'https://open.bigmodel.cn/api/anthropic' }}

--- a/.github/workflows/agent-weekly.yml
+++ b/.github/workflows/agent-weekly.yml
@@ -29,8 +29,8 @@ jobs:
       prompt: "/weekly-report"
       model: ${{ vars.CLAUDE_MODEL || 'glm-5.1' }}
       api-provider: "anthropic"
-      max-turns: 25
-      timeout-minutes: 25
+      max-turns: 50
+      timeout-minutes: 35
     secrets:
       api-key: ${{ secrets.GLM_API_KEY }}
       api-base-url: ${{ secrets.GLM_BASE_URL || 'https://open.bigmodel.cn/api/anthropic' }}


### PR DESCRIPTION
Both workflows hit 'Reached maximum number of turns' on the first GLM-Coding-Plan dispatch (runs 25239135689 daily, 25239136403 weekly). Daily: 20→40 turns + 15→25 minute timeout. Weekly: 25→50 turns + 25→35 minute timeout.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/YiAgent/codesmith/EvolveCI/pr/8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configurations to increase processing capacity and timeout durations for automated daily and weekly reporting tasks, enhancing system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->