### PR TITLE
refactor(memory): replace memory/ files with GitHub Issues

### DIFF
--- a/.claude/commands/check-circuit.md
+++ b/.claude/commands/check-circuit.md
@@ -1,82 +1,76 @@
-# /check-circuit — 熔断器状态检查与管理
+# /check-circuit — 熔断器状态（Issue 内存模型）
 
-**触发方式**：由 `/triage` 在每次运行开始时调用，或手动执行以查看熔断器状态。
+**触发方式**：由 `/triage` / `/heartbeat` 在每次运行开始时调用，或手动执行查看状态。
 
-## 熔断器状态文件
+> 内存模型：单一 `evolveci/circuit` Issue 持有熔断器 JSON state。本命令的全部
+> 操作都在该 issue 上完成（编辑 body / 追加 comment）。详见 `docs/MEMORY-MODEL.md`。
 
-`memory/circuit/state.json` 格式：
+## 状态结构
+
 ```json
 {
   "active": false,
-  "reason": "",
   "tripped_at": null,
-  "tripped_dimension": null,
-  "auto_recover_at": null,
-  "history": []
+  "tripped_reason": null,
+  "tripped_by": null,
+  "history": [
+    { "ts": "...", "event": "tripped|recovered", "reason": "..." }
+  ]
 }
 ```
 
-## 执行步骤
+## 读取
 
-### 查询状态（默认操作）
+```bash
+ISSUE=$(gh issue list --label evolveci/circuit --state all -L 1 \
+        --json number --jq '.[0].number // empty')
 
-读取 `memory/circuit/state.json` 并输出当前状态：
+if [ -z "$ISSUE" ]; then
+  # 首次运行 — 创建带默认 state 的 issue
+  gh issue create \
+    --title "EvolveCI circuit breaker" \
+    --label "evolveci/circuit,severity/info" \
+    --body '{"active":false,"tripped_at":null,"tripped_reason":null,"tripped_by":null,"history":[]}'
+  ISSUE=$(gh issue list --label evolveci/circuit --state all -L 1 \
+            --json number --jq '.[0].number')
+fi
 
-- `active: false` → 输出"熔断器正常，可执行自动操作"
-- `active: true` → 输出详细信息：
-  - 触发时间
-  - 触发维度（workflow/pattern/repo）
-  - 触发原因
-  - 预计自动恢复时间（`tripped_at` + 24h）
-  - 相关 GitHub Issue 链接（从 `reason` 中提取）
-
-### 自动恢复检查
-
-若 `active: true` 且 `tripped_at` 距今 ≥ 24h：
-
-1. 将 `active` 设为 `false`，清空 `reason`/`tripped_at`/`tripped_dimension`
-2. 在 `history` 数组追加恢复记录：
-   ```json
-   {
-     "tripped_at": "<原触发时间>",
-     "recovered_at": "<当前ISO8601时间>",
-     "reason": "<原触发原因>",
-     "recovered_by": "auto"
-   }
-   ```
-3. 在对应 GitHub Issue（通过 `reason` 字段中的 Issue 编号找到）添加 comment：
-   ```
-   熔断器已自动恢复（24小时超时）。EvolveCI 将恢复自动分诊。
-   ```
-4. 写回 `memory/circuit/state.json`
-5. 提交：`memory: circuit-recover — auto-recovered after 24h`
-
-### 触发熔断（由 triage 内部调用）
-
-当重跑计数超过预算时：
-
-1. 读取计数器确认维度和原因
-2. 更新 `memory/circuit/state.json`：
-   ```json
-   {
-     "active": true,
-     "reason": "<维度>超限：<repo>/<workflow> 今日已重跑 <N> 次",
-     "tripped_at": "<当前ISO8601时间>",
-     "tripped_dimension": "<workflow|pattern|repo>",
-     "auto_recover_at": "<tripped_at + 24h>"
-   }
-   ```
-3. 通过 GitHub MCP 创建 Issue：
-   - 标题：`[熔断器] <repo>/<workflow> - <维度>预算超限`
-   - 标签：`ci:circuit-broken`、`severity/critical`
-   - 正文说明触发原因、预算配置来源（`data/circuit-config.yml`）、手动恢复方法
-4. 发送 Slack 通知（若配置了 webhook）
-5. 提交：`memory: circuit-trip — <维度> budget exceeded for <repo>/<workflow>`
-
-## 手动恢复方法
-
-若需人工干预恢复熔断器，可通过 `workflow_dispatch` 触发并在 prompt 中说明：
+STATE=$(gh issue view "$ISSUE" --json body --jq .body)
 ```
-/check-circuit recover
+
+## 跳闸 (trip)
+
+由 publisher 在超出预算时调用：
+
+```bash
+NEW=$(echo "$STATE" | jq --arg ts "$(date -u +%FT%TZ)" \
+                         --arg reason "$REASON" \
+                         --arg by "$TRIGGER_RUN_URL" \
+  '.active=true | .tripped_at=$ts | .tripped_reason=$reason | .tripped_by=$by
+   | .history += [{ts:$ts, event:"tripped", reason:$reason}]')
+
+gh issue edit "$ISSUE" --body "$NEW"
+gh issue comment "$ISSUE" --body "🔴 熔断器跳闸：${REASON} ([触发 run](${TRIGGER_RUN_URL}))"
 ```
-这会强制将 `active` 设为 `false` 并记录 `recovered_by: "manual"`。
+
+## 自动恢复 (recover)
+
+`/triage` 或 `/heartbeat` 发现 `active=true` 且 `tripped_at` ≥24h：
+
+```bash
+NEW=$(echo "$STATE" | jq --arg ts "$(date -u +%FT%TZ)" \
+  '.active=false | .tripped_at=null | .tripped_reason=null | .tripped_by=null
+   | .history += [{ts:$ts, event:"recovered", reason:"auto-recover (>24h)"}]')
+
+gh issue edit "$ISSUE" --body "$NEW"
+gh issue comment "$ISSUE" --body "🟢 自动恢复于 $(date -u +%FT%TZ)（已停留 ≥24h）"
+```
+
+## 手动检查
+
+显示当前 state 摘要，不修改任何东西。
+
+## 不做什么
+
+- 不写 `memory/circuit/state.json`
+- 不 git commit

--- a/.claude/commands/daily-report.md
+++ b/.claude/commands/daily-report.md
@@ -1,91 +1,94 @@
-# /daily-report — 生成每日 CI 健康报告
+# /daily-report — 生成每日 CI 健康报告（Issue 内存模型）
 
 **触发方式**：由 `agent-daily.yml` 工作日 UTC 01:00 调用，或通过 `workflow_dispatch` 手动触发。
 
+> 内存模型：每天一个 `evolveci/daily` Issue。同日重跑 → 编辑 body 而非新建。
+> 详见 `docs/MEMORY-MODEL.md`。
+
 ## 执行步骤
 
-### 步骤 1：采集 24 小时数据
+### 步骤 1：聚合最近 24 小时数据
 
-- 读取 `data/onboarded-repos.yml` 获取监控仓库列表
-- 对每个仓库，用 GitHub MCP 工具查询过去 24 小时内所有 workflow runs（all status）
-- 按 `repo/workflow` 分组，计算：
-  - `total_runs`：总次数
-  - `failed_runs`：失败次数
-  - `success_runs`：成功次数
-  - `failure_rate`：失败率（%）
-  - `timed_out_runs`：超时次数
+通过 `mcp__github_ci__*` 与 `gh api` 收集（覆盖 `data/onboarded-repos.yml` 中
+全部仓库）：
 
-### 步骤 2：检测退化
+- 总 workflow run 数、成功率、失败率
+- 按 workflow 维度的 top-5 失败
+- 平均运行时长、p95 运行时长
+- flaky run 比例（用 `evolveci/triage` + `category:flaky` 过滤）
+- 当日新建 / 仍 open 的 `evolveci/triage` 数量
+- 当日 auto-rerun 触发次数、新增 `evolveci/pattern` 数量
 
-- 读取 `memory/stats/daily/` 最近 7 天的 JSON 快照
-- 对每个 workflow，计算 7 天平均失败率
-- 若今日失败率比 7 天均值高 **≥10 个百分点** → 标记为退化（`degraded: true`）
-- 若某 workflow 今日出现但 7 天历史中无记录 → 标记为新 workflow
-
-### 步骤 3：生成报告内容
-
-使用我自己的分析能力生成中文日报（参考 `prompts/observability/daily-report.md` 的格式要求）：
-
-报告结构：
-```markdown
-## CI 日报 — YYYY-MM-DD
-
-### TL;DR
-<2-3 句话总结今日 CI 健康状况，高亮最重要的问题>
-
-### 关键指标
-
-| 指标 | 数值 |
-|------|------|
-| 监控仓库数 | N |
-| 总 workflow 运行次数 | N |
-| 失败次数 | N |
-| 整体失败率 | N% |
-| 自动重跑次数 | N |
-
-### 退化预警 ⚠️
-<列出失败率显著上升的 workflow，含今日 vs 7 天均值对比>
-
-### Top Flaky Workflows
-<失败率最高的前 5 个 workflow>
-
-### 建议行动项
-<基于今日数据的 2-5 条具体建议>
-```
-
-### 步骤 4：持久化与发布
-
-1. 写入 `memory/stats/daily/<今日日期>.json`（原始数据快照）
-2. 通过 GitHub MCP 创建 GitHub Issue：
-   - 标题：`CI 日报 - YYYY-MM-DD`
-   - 标签：`daily-report`、`ci-health`
-   - 正文：步骤 3 生成的 markdown 报告
-3. 若有 `severity=critical` 的退化 → 同时发送 Slack 通知
-
-### 步骤 5：提交记忆
+### 步骤 2：检测退化（与上一工作日对比）
 
 ```bash
-git add memory/stats/daily/
-git commit -m "memory: daily-report — health snapshot YYYY-MM-DD, failure_rate=N%"
-git push origin main
+PREV=$(gh issue list --label evolveci/daily -L 5 --json number,title,body \
+        --jq '.[] | select(.title | startswith("Daily Report — "))')
 ```
 
-## 每日统计 JSON 格式
+取前一份与当前的关键指标对比，标出 ≥20% 的劣化项。
 
-`memory/stats/daily/YYYY-MM-DD.json`：
-```json
-{
-  "date": "YYYY-MM-DD",
-  "total_runs": 127,
-  "total_failures": 14,
-  "failure_rate": 11,
-  "trend": "stable",
-  "trend_delta": 2,
-  "workflows": [
-    {"key": "org/repo/ci.yml", "total": 45, "failed": 3, "failure_rate": 6}
-  ],
-  "degradations": [
-    {"key": "org/repo/pr.yml", "current": 13, "avg_7day": 5, "delta": 8}
-  ]
-}
+### 步骤 3：在 issue 上 upsert
+
+```bash
+TODAY=$(date -u +%Y-%m-%d)
+TITLE="Daily Report — ${TODAY}"
+
+# 是否已有今天的 issue？通过标题前缀搜索（in:title）
+EXISTING=$(gh issue list --label evolveci/daily \
+            --search "in:title \"${TITLE}\"" -L 1 \
+            --json number --jq '.[0].number // empty')
+
+REPORT_BODY=$(render-report)  # 渲染 markdown 报告
+
+if [ -n "$EXISTING" ]; then
+  gh issue edit "$EXISTING" --body "$REPORT_BODY"
+else
+  gh issue create \
+    --title "$TITLE" \
+    --label "evolveci/daily,severity/info" \
+    --body "$REPORT_BODY"
+fi
 ```
+
+### 步骤 4（可选）：Slack 摘要
+
+若有 ≥1 项关键指标恶化，向 `SLACK_WEBHOOK_URL` 发送一条短摘要 + Issue 链接。
+
+## 报告 markdown 模板
+
+```markdown
+# Daily Report — {{today}}
+
+**生成时间**: {{generated_at}} UTC
+
+## 总览
+
+| 指标 | 今日 | 昨日 | 趋势 |
+|------|------|------|------|
+| run 总数 | … | … | ↑/↓/→ |
+| 成功率 | …% | …% | … |
+| flaky 比例 | …% | …% | … |
+| MTTR (h) | … | … | … |
+
+## 当日新增 triage
+
+- #1234 `repo · workflow · step` (severity/critical, category:infra)
+- #1235 …
+
+## 仍 open 的 triage（>24h）
+
+…
+
+## 学习
+
+- 新增 `evolveci/pattern` × N
+- auto-rerun 触发 × N
+- 熔断器状态：active=…
+```
+
+## 不做什么
+
+- 不写 `memory/stats/daily/<date>.json`
+- 不 git commit
+- 不 push 任何分支

--- a/.claude/commands/heartbeat.md
+++ b/.claude/commands/heartbeat.md
@@ -1,71 +1,118 @@
-# /heartbeat — 自我健康监控
+# /heartbeat — 自我健康监控（基于 Issue 内存模型）
 
 **触发方式**：由 `agent-heartbeat.yml` 每 6 小时调用。
 
+> 内存模型：所有持久化状态都存放在带 `evolveci/*` 前缀标签的 Issue 中。
+> 详见 `docs/MEMORY-MODEL.md`。
+
 ## 执行步骤
 
-依次执行以下 5 个探针，任一关键探针失败则触发告警。
+依次执行以下 5 个探针，任一关键探针失败 → 在 `evolveci/heartbeat` Issue 上累加；
+全部通过 → 关闭任何尚处 open 的 `evolveci/heartbeat` Issue。
 
 ### 探针 1：Triage 活跃度（关键）
 
-检查 `memory/incidents/` 目录：
-- 找到最新的 `.jsonl` 文件（按文件名/路径排序）
-- 读取最后一行，检查 `ts` 字段的 ISO8601 时间戳
-- 若距今 > 24h → **失败**：triage 超过 24 小时未运行
+查询近 24 小时内被更新的 triage Issue：
 
-**预期**：每 15 分钟 triage 一次，24h 内至少有 1 条记录。
+```bash
+SINCE=$(date -u -d '24 hours ago' +%FT%TZ 2>/dev/null || date -u -v-24H +%FT%TZ)
+COUNT=$(gh issue list --label evolveci/triage --state all \
+  --search "updated:>${SINCE}" --json number -L 1 | jq length)
+```
+
+`COUNT == 0` → **失败**：triage 超过 24 小时未运行。
 
 ### 探针 2：模式库健康（关键）
 
-读取 `memory/patterns/known-patterns.json`：
-- 统计条目数
-- 若 < 10 条 → **失败**：模式库条目过少（可能文件损坏）
-- 验证 JSON 格式是否有效（通过 `jq . memory/patterns/known-patterns.json` 检查）
+```bash
+COUNT=$(gh issue list --label evolveci/pattern --state all -L 100 --json number | jq length)
+```
+
+`COUNT < 10` → **失败**：模式库条目过少（首次运行后应已从 `data/known-patterns.seed.json` 种入）。
 
 ### 探针 3：统计数据新鲜度（警告）
 
-读取 `memory/stats/daily/` 目录：
-- 找到最新的 `.json` 文件
-- 检查文件的 `date` 字段
-- 若距今 > 48h → **警告**：daily-report 超过 48 小时未运行
+近 48 小时内是否有更新过的 `evolveci/daily` Issue：
 
-### 探针 4：熔断器状态检查（信息）
+```bash
+SINCE=$(date -u -d '48 hours ago' +%FT%TZ 2>/dev/null || date -u -v-48H +%FT%TZ)
+COUNT=$(gh issue list --label evolveci/daily --state all \
+  --search "updated:>${SINCE}" --json number -L 1 | jq length)
+```
 
-读取 `memory/circuit/state.json`：
-- 若 `active: true` 且 `tripped_at` 距今 > 24h：
-  - 自动恢复（参考 `/check-circuit` 命令）
-  - 记录为警告而非失败
-- 若 `active: true` 且 < 24h：
-  - 记录为信息（熔断器正常工作中，不视为故障）
+`COUNT == 0` → **警告**：daily-report 超过 48 小时未运行。
 
-### 探针 5：目录完整性（关键）
+### 探针 4：熔断器状态（信息）
 
-检查以下目录是否存在：
-- `memory/patterns/`
-- `memory/incidents/`
-- `memory/stats/daily/`
-- `memory/stats/weekly/`
-- `memory/fingerprints/`
-- `memory/circuit/`
-- `memory/counters/`
+读取唯一 `evolveci/circuit` Issue 的 body（JSON），检查 `active` 与 `tripped_at`：
 
-若任一不存在 → **失败**：内存目录结构损坏。
+```bash
+BODY=$(gh issue list --label evolveci/circuit --state all -L 1 --json body --jq '.[0].body // empty')
+ACTIVE=$(echo "$BODY" | jq -r '.active // false')
+TRIPPED=$(echo "$BODY" | jq -r '.tripped_at // empty')
+```
 
-## 告警决策
+- `active=true` 且距 `tripped_at` > 24h → 自动恢复（参考 `/check-circuit`），记为**警告**而非失败。
+- `active=true` 且 < 24h → 记为**信息**（熔断器正常工作中）。
+- 没有 `evolveci/circuit` Issue → 创建一个，body 为 `{"active":false,"history":[]}`。
 
-| 状态 | 条件 | 动作 |
-|------|------|------|
-| 全部健康 | 所有关键探针通过 | 仅输出日志，无动作 |
-| 警告 | 仅非关键探针失败 | 记录警告日志 |
-| 故障 | 任一关键探针失败 | 创建 GitHub Issue + Slack 通知 |
+### 探针 5：标签完整性（关键）
 
-### 故障 Issue 格式
+```bash
+gh label list --limit 100 --json name --jq '.[].name' | grep -c '^evolveci/'
+```
 
-- 标题：`[EvolveCI 健康告警] <探针名称> 失败`
-- 标签：`heartbeat-alert`、`severity/high`
-- 正文：说明失败探针、期望值、实际值、可能原因、建议修复步骤
+返回 `< 5` → **失败**：标签未初始化。提示运行 `bash scripts/bootstrap-labels.sh <owner/repo>`。
 
-## 无需提交记忆
+## 上报：累加到现有 heartbeat Issue 或新建
 
-Heartbeat 本身不产生需要持久化的状态（它是只读探针），**不需要 git commit**。
-若触发了熔断器自动恢复，恢复逻辑本身会在 `/check-circuit` 中处理提交。
+任一关键探针失败时：
+
+```bash
+EXISTING=$(gh issue list --label evolveci/heartbeat --state open -L 1 \
+            --json number --jq '.[0].number // empty')
+
+REPORT="## 心跳报告 — $(date -u +%FT%TZ)
+
+- 探针 1（triage 活跃度）: <status>
+- 探针 2（模式库健康）: <status>
+- 探针 3（数据新鲜度）: <status>
+- 探针 4（熔断器状态）: <status>
+- 探针 5（标签完整性）: <status>
+
+failed_critical: <list>
+
+[run]({{run_url}})"
+
+if [ -n "$EXISTING" ]; then
+  gh issue comment "$EXISTING" --body "$REPORT"
+else
+  gh issue create \
+    --title "EvolveCI heartbeat alert — $(date -u +%Y-%m-%d)" \
+    --label evolveci/heartbeat,severity/critical \
+    --body "$REPORT"
+fi
+```
+
+## 全部通过时：关闭现有 heartbeat Issue
+
+```bash
+EXISTING=$(gh issue list --label evolveci/heartbeat --state open -L 1 \
+            --json number --jq '.[0].number // empty')
+if [ -n "$EXISTING" ]; then
+  gh issue comment "$EXISTING" --body "全部探针在 $(date -u +%FT%TZ) 恢复正常。"
+  gh issue edit "$EXISTING" --add-label status/recovered
+  gh issue close "$EXISTING"
+fi
+```
+
+## Slack 通知（可选）
+
+任何 `severity/critical` 探针失败时，且 `SLACK_WEBHOOK_URL` 存在 → 发送一条
+摘要消息（标题 + 失败探针名 + Issue URL）。
+
+## 不做什么
+
+- 不写 `memory/` 任何文件
+- 不 git commit
+- 不 push 任何分支

--- a/.claude/commands/learn-pattern.md
+++ b/.claude/commands/learn-pattern.md
@@ -1,94 +1,72 @@
-# /learn-pattern — 学习并记录新失败模式
+# /learn-pattern — 学习并记录新失败模式（写入 evolveci/pattern Issue）
 
 **触发方式**：由 `/triage` 在 Tier 3 分析中发现可复用模式时内部调用。
 
-## 参数（在 prompt 中以自然语言描述）
+> 内存模型：每个 pattern 是一条带 `evolveci/pattern` 标签的 GitHub Issue，
+> body 为 JSON。详见 `docs/MEMORY-MODEL.md`。
 
-- `pattern`：正则表达式字符串
-- `category`：`flaky` | `infra` | `code` | `dependency` | `security` | `unknown`
-- `severity`：`low` | `medium` | `high` | `critical`
-- `run_id`：发现该模式的 run ID
-- `repo`：仓库名（org/repo）
-- `summary`：一句话描述该模式
-
-## 执行步骤
-
-### 步骤 1：安全验证
-
-在记录模式前，必须通过以下所有检查：
-
-```bash
-# 1. 长度检查
-[ ${#PATTERN} -le 200 ] || { echo "ERROR: pattern too long"; exit 1; }
-
-# 2. 禁止嵌套量词
-echo "$PATTERN" | grep -qE '\(\.\*\)\+|\(\.\+\)\+|\(\[.*\]\)\+' && { echo "ERROR: nested quantifier"; exit 1; }
-
-# 3. 语法有效性
-echo "test" | grep -qE "$PATTERN" 2>&1; [ $? -ne 2 ] || { echo "ERROR: invalid regex"; exit 1; }
-```
-
-若任一检查失败，记录警告日志并退出（不保存 pattern）。
-
-### 步骤 2：去重检查
-
-读取 `memory/patterns/known-patterns.json`，检查：
-- 是否已有 `id` 完全相同的 pattern
-- 是否已有 `match` 字段与新 pattern 字符重叠 >80%（简单子串检查即可）
-
-若去重命中 → 输出提示"模式已存在：<existing-id>"，退出（不重复保存）。
-
-### 步骤 3：生成 Pattern ID
-
-根据 summary 生成简短 kebab-case ID，例如：
-- "GitHub registry rate limit" → `ghcr-rate-limit-v2`
-- "pip install SSL error" → `pip-ssl-error`
-
-检查 ID 是否已存在于 JSON，若冲突则追加 `-v2`、`-v3` 等。
-
-### 步骤 4：追加到模式库
-
-读取 `memory/patterns/known-patterns.json`，追加新条目：
+## 输入
 
 ```json
 {
-  "id": "<生成的ID>",
-  "match": "<正则表达式>",
-  "category": "<category>",
-  "auto_rerun": <flaky/infra时考虑true，code/security时false>,
-  "notify": <severity>=high/critical时true，否则false>,
-  "severity": "<severity>",
-  "seen_count": 1,
-  "last_seen": "<今日日期YYYY-MM-DD>",
-  "source": "agent-learned",
-  "discovered_from": "<run_id>",
-  "summary": "<一句话描述>"
+  "id": "kebab-case-id",
+  "match": "<regex>",
+  "category": "flaky | infra | code | dependency | unknown",
+  "severity": "critical | warning | info",
+  "auto_rerun": true,
+  "notify": false,
+  "description": "human-readable",
+  "examples": ["sample log line 1", "..."]
 }
 ```
 
-**`auto_rerun` 决策规则**：
-- `category=flaky` → `auto_rerun: true`
-- `category=infra` + `severity=low/medium` → `auto_rerun: true`
-- `category=code` / `category=security` / `severity=high/critical` → `auto_rerun: false`
+## 安全校验（必做）
 
-### 步骤 5：更新 CLAUDE.md（高 severity 时）
+按 `CLAUDE.md` 中的规则：
 
-若 `severity=high` 或 `severity=critical`，在 CLAUDE.md 的"近期学习"章节追加：
-```
-<今日日期>: <pattern-id> — <summary>
-```
+- 长度 ≤200 字符
+- 禁止嵌套量词 `(.*)+`、`(.+)+`
+- 必须能编译（`echo '<regex>' | python3 -c 'import re,sys; re.compile(sys.stdin.read().strip())'`）
+- 不能匹配空字符串
 
-### 步骤 6：提交
+任何一项失败 → 拒绝，不创建 Issue。
+
+## 写入 Issue
 
 ```bash
-git add memory/patterns/known-patterns.json CLAUDE.md
-git commit -m "memory: learn-pattern — <pattern-id> (<category>, <severity>)"
-git push origin main
+PATTERN_JSON=$(jq -nc \
+  --arg id "$ID" \
+  --arg match "$MATCH" \
+  --arg category "$CATEGORY" \
+  --arg severity "$SEVERITY" \
+  --argjson auto_rerun "$AUTO_RERUN" \
+  --argjson notify "$NOTIFY" \
+  --arg description "$DESCRIPTION" \
+  --argjson examples "$EXAMPLES_JSON_ARRAY" \
+  '{id:$id, match:$match, category:$category, severity:$severity,
+    auto_rerun:$auto_rerun, notify:$notify,
+    description:$description, examples:$examples,
+    learned_at: now | strftime("%Y-%m-%dT%H:%M:%SZ")}')
+
+# 检查是否已经存在同 id 的 pattern issue
+EXISTING=$(gh issue list --label evolveci/pattern --search "in:title pattern: ${ID}" \
+            -L 1 --json number --jq '.[0].number // empty')
+
+if [ -n "$EXISTING" ]; then
+  # 已有同名 → 视情况编辑（更新描述 / 加 examples）
+  gh issue comment "$EXISTING" --body "${ID} 重新学习于 $(date -u +%FT%TZ)"
+  gh issue edit "$EXISTING" --body "$PATTERN_JSON"
+else
+  gh issue create \
+    --title "pattern: ${ID}" \
+    --label "evolveci/pattern,severity/${SEVERITY},category:${CATEGORY}" \
+    --body "$PATTERN_JSON"
+fi
 ```
 
-## 重要说明
+## 不做什么
 
-- 不再需要 PR 审核流程——Claude 直接写入 main 分支
-- 安全检查（步骤 1）替代了人工审核
-- 新 pattern 在下次 triage（15 分钟后）立即生效
-- 若对某个模式不确定，宁可不记录（keep Tier 3），避免引入干扰规则
+- 不写 `memory/patterns/known-patterns.json`
+- 不 git commit
+- 不 push 任何分支
+- 永远不要从用户输入直接拼接 regex（必须经过校验）

--- a/.claude/commands/triage.md
+++ b/.claude/commands/triage.md
@@ -1,95 +1,152 @@
-# /triage — 实时 CI 故障分诊
+# /triage — 实时 CI 故障分诊（基于 Issue 内存模型）
 
 **触发方式**：由 `agent-triage.yml` 每 15 分钟调用，或通过 `workflow_dispatch` 手动触发。
+
+> 内存模型：fingerprints / 已知 patterns / 历史 incidents 都是带 `evolveci/*`
+> 标签的 GitHub Issue。详见 `docs/MEMORY-MODEL.md`。
 
 ## 执行步骤
 
 ### 步骤 1：检查熔断器
 
-读取 `memory/circuit/state.json`：
-- 如果 `active: true` 且 `tripped_at` 距今 < 24h → 停止所有自动动作，输出警告后退出
-- 如果 `active: true` 且距今 ≥ 24h → 自动恢复：将 `active` 设为 `false`，更新 `history`，写回文件，在对应 GitHub Issue 添加恢复 comment
+读取唯一 `evolveci/circuit` Issue 的 body：
+
+```bash
+BODY=$(gh issue list --label evolveci/circuit --state all -L 1 \
+        --json body --jq '.[0].body // empty')
+ACTIVE=$(echo "$BODY" | jq -r '.active // false')
+TRIPPED=$(echo "$BODY" | jq -r '.tripped_at // empty')
+```
+
+- `active=true` 且距 `tripped_at` < 24h → 输出警告后退出，不执行任何动作。
+- `active=true` 且 ≥ 24h → 自动恢复（编辑 issue body 把 `active` 设为 `false`，
+  追加一条 `gh issue comment` 记录恢复时间），然后继续。
 
 ### 步骤 2：加载上下文
 
-- 读取 `data/onboarded-repos.yml` 获取监控仓库列表
-- 读取 `memory/patterns/known-patterns.json` 加载已知模式（用于 Tier 1）
-- 读取 `memory/counters/<今日日期>.json`（不存在则初始化为空计数器）
+- `data/onboarded-repos.yml` — 监控仓库列表（仍是文件）。
+- 已知 patterns（替换原 `memory/patterns/known-patterns.json`）：
+
+  ```bash
+  gh issue list --label evolveci/pattern --state all -L 100 \
+    --json body --jq '.[].body' | while read -r b; do
+      echo "$b" | jq -c .   # 每个 pattern 是 body 里的 JSON 对象
+    done > /tmp/patterns.jsonl
+  ```
+
+- 当日重跑计数器：放在内存（无需持久化文件）；超出预算时通过 step 4d 在
+  `evolveci/circuit` issue 上记录。
 
 ### 步骤 3：查询失败
 
-对每个监控仓库，使用 GitHub MCP 工具查询最近 30 分钟内状态为 `failure` 或 `timed_out` 的 workflow runs。
-- 若仓库配置了 `workflows` 字段（非 `"*"`），只查询指定 workflow
-- 合并所有仓库结果，按时间倒序排列，**最多取 10 条**处理
+对每个监控仓库通过 GitHub MCP 查询最近 30 分钟内 `failure` / `timed_out` 的
+workflow runs；合并所有仓库结果，按时间倒序排列，**最多取 10 条**处理。
 
 ### 步骤 4：逐条分析
 
-对每条失败 run，依次执行：
+对每条失败 run 依次执行：
 
-**a. 获取日志**
-- 通过 GitHub MCP 获取失败步骤的日志（优先获取最后 100 行）
-- 用 Bash 调用 `lib/redact-log.sh` 脱敏：`echo "$LOG" | bash lib/redact-log.sh`
+#### a. 获取日志
 
-**b. 生成指纹**
-- 提取日志中的错误行（`error:`、`fatal:`、`FAILED`、`Error:` 等关键词所在行）
-- 结合失败的 step name，用 Bash 计算：`echo "<错误行+step>" | sha256sum | cut -c1-12`
+通过 GitHub MCP 获取失败步骤的最后 100 行；用
+`echo "$LOG" | bash lib/redact-log.sh` 脱敏。
 
-**c. 去重检查**
-- 查找 `memory/fingerprints/<fingerprint>.json` 是否存在
-- 若存在且 `linked_issue` 有值：在对应 Issue 添加 comment（记录新发生次数），**跳过**建新 Issue
-- 若存在但无 `linked_issue`：继续正常流程
-- 若不存在：继续正常流程
+#### b. 生成指纹
 
-**d. Tier 1 — 正则匹配**
-- 对脱敏日志逐条测试 `known-patterns.json` 中每条 `match` 正则
-- 命中 → 使用该 pattern 的 `auto_rerun`/`notify`/`severity`/`category`，记录 `pattern_id`，跳至步骤 5
+```bash
+FP=$(printf '%s' "${ERROR_LINES}|${STEP_NAME}" | sha256sum | cut -c1-12)
+```
 
-**e. Tier 2 — 启发式关键词**（Tier 1 未命中时）
-- 按 CLAUDE.md 中"Tier 2 启发式规则"表格逐条匹配
-- 高/中置信度 → 决策并记录 `category`/`severity`，跳至步骤 5
-- 低置信度 → 进入 Tier 3
+#### c. 去重检查（基于 issue 标签）
 
-**f. Tier 3 — 深度推理**（Tier 1+2 均未高置信命中时）
-- 使用我自己的推理能力分析脱敏日志
-- 参考 `prompts/observability/classify-failure-sonnet.md` 的分析框架和输出格式
-- 输出：`category`、`severity`、`summary`、`root_cause`、`fix_suggestion`
-- 若发现可复用正则模式，调用 `/learn-pattern` 命令记录
+```bash
+EXISTING=$(gh issue list --label "fingerprint:${FP}" --state open -L 1 \
+            --json number --jq '.[0].number // empty')
+
+if [ -n "$EXISTING" ]; then
+  # 在已有 issue 上累加
+  CURRENT=$(gh issue view "$EXISTING" --json body --jq .body)
+  N=$(echo "$CURRENT" | grep -oE '^occurrences: [0-9]+' | head -1 | awk '{print $2}')
+  N=$((${N:-1} + 1))
+  NEW_BODY=$(echo "$CURRENT" | sed "s/^occurrences: .*$/occurrences: $N/")
+  gh issue edit "$EXISTING" --body "$NEW_BODY"
+  gh issue comment "$EXISTING" --body "再次发生于 $(date -u +%FT%TZ) — [run]({{run_url}})"
+  # 跳到下一条 failure
+  continue
+fi
+```
+
+#### d. Tier 1 — 正则匹配
+
+逐条用 `/tmp/patterns.jsonl` 的 `match` 字段对脱敏日志做正则匹配。
+命中 → 使用该 pattern 的 `auto_rerun` / `notify` / `severity` / `category`，
+记录 `pattern_id`，跳到步骤 5。
+
+#### e. Tier 2 — 启发式关键词
+
+按 `CLAUDE.md` 中"Tier 2 启发式规则"表格逐条匹配。
+
+#### f. Tier 3 — 深度推理
+
+我用自己的推理能力分析脱敏日志（参考 `prompts/observability/classify-failure-sonnet.md`）。
+若发现可复用正则模式，调用 `/learn-pattern` 命令把它写入新的 `evolveci/pattern` Issue。
 
 ### 步骤 5：执行动作
 
-根据分析结果：
+根据分类与置信度：
 
-| 条件 | 动作 |
-|------|------|
-| `auto_rerun=true` + 未超预算 + workflow 名不含禁止关键词 | `gh run rerun <run_id> --repo <repo> --failed` |
-| 重跑后计数器超过 workflow 日限 | 调用 trip-circuit-breaker：更新 `memory/circuit/state.json` + 建 Issue |
-| `notify=true` + `category != flaky` | 通过 GitHub MCP 创建 Issue（或更新已有 Issue） |
-| `severity` 为 `critical` 或 `high` | 通过 Bash curl 发送 Slack webhook 通知 |
+- **flaky** → 自动重跑（受熔断器/预算约束），不建 Issue 通知。
+- **infra/code/dependency/unknown** → 在第 4c 步未命中已有 issue 时新建一条：
 
-### 步骤 6：写入记忆
+  ```bash
+  REPO_LABEL="repo:$(echo "$REPO" | tr '/' '-')"
+  # 自动确保 repo: 标签存在（label create --force 是幂等的）
+  gh label create "$REPO_LABEL" --color "ededed" \
+    --description "Repo facet" --force >/dev/null
 
-处理完所有失败后，更新以下文件并提交：
+  gh label create "fingerprint:${FP}" --color "ededed" \
+    --description "Fingerprint dedup" --force >/dev/null
 
-1. **`memory/fingerprints/<fp>.json`**：新建或更新（`count++`、`last_seen`、追加 `linked_runs`）
-2. **`memory/counters/<今日日期>.json`**：更新重跑计数、分诊次数、各 Tier 命中数
-3. **`memory/incidents/<YYYY-MM>/<YYYY-MM-DD>.jsonl`**：追加本次每条失败的 incident 记录
+  gh issue create \
+    --title "${REPO} · ${WORKFLOW} · ${STEP} failure" \
+    --label "evolveci/triage,severity/${SEVERITY},category:${CATEGORY},${REPO_LABEL},fingerprint:${FP}" \
+    --body "$(cat <<EOF
+fingerprint: ${FP}
+occurrences: 1
+last_seen: $(date -u +%FT%TZ)
+category: ${CATEGORY}
+severity: ${SEVERITY}
+pattern_id: ${PATTERN_ID:-none}
+run: {{run_url}}
 
-Incident 记录格式（每行一个 JSON）：
-```json
-{"ts":"<ISO8601>","run_id":"<id>","repo":"<org/repo>","workflow":"<name>.yml","fingerprint":"<12hex>","category":"<cat>","severity":"<sev>","tier":<1|2|3>,"action":"<rerun|issue|skip>","pattern_id":"<id或null>","summary":"<一句话>"}
-```
+## 摘要
 
-提交命令：
-```bash
-git config user.name "EvolveCI Agent"
-git config user.email "evolveci-agent@users.noreply.github.com"
-git add memory/
-git commit -m "memory: triage — <N> failures processed, <M> new patterns"
-git push origin main
-```
+${SUMMARY}
 
-## 约束
+## 根因猜测
 
-- 单次 triage 最多处理 10 条失败（防止超时）
-- 禁止重跑的 workflow 关键词：`deploy`、`release`、`security`、`scan`、`sign`、`publish`
-- Tier 3 分析时，日志长度限制 ≤32768 字符（超出则截取最后 32768 字符）
+${ROOT_CAUSE}
+
+## 修复建议
+
+${FIX_SUGGESTION}
+
+## 脱敏日志摘要
+
+\`\`\`
+${REDACTED_TAIL}
+\`\`\`
+EOF
+)"
+  ```
+
+### 步骤 6：累计计数（可选 Slack）
+
+`severity/critical` 或 `category:infra` 的告警建议同时发送 Slack 通知（如
+`SLACK_WEBHOOK_URL` 存在）。
+
+## 不做什么
+
+- 不写 `memory/incidents/`、`memory/fingerprints/`、`memory/counters/`
+- 不 git commit
+- 不 push 任何分支

--- a/.claude/commands/weekly-report.md
+++ b/.claude/commands/weekly-report.md
@@ -1,119 +1,108 @@
-# /weekly-report — 生成每周 CI 深度分析报告
+# /weekly-report — 每周深度复盘（提交 PR）
 
 **触发方式**：由 `agent-weekly.yml` 每周一 UTC 02:00 调用，或通过 `workflow_dispatch` 手动触发。
 
+> 这是四个 agent 中**唯一**会动 git 的命令：它在新分支上更新 `CLAUDE.md`
+> 的"近期学习"章节，并打开一个 PR 等待 squash-merge。日报 / 心跳 / triage
+> 全部走 Issue。详见 `docs/MEMORY-MODEL.md`。
+
 ## 执行步骤
 
-### 步骤 1：采集 7 天数据
+### 步骤 1：聚合 7 天数据
 
-- 合并 `memory/stats/daily/` 最近 7 天的 JSON 快照
-- 读取上周的 `memory/stats/weekly/<上周Week>.json` 用于对比
-- 读取本周所有 `memory/incidents/<YYYY-MM>/<date>.jsonl` 统计 Tier 分布
+- 列出最近一周更新过的 `evolveci/triage`（含已关闭）：
+  ```bash
+  SINCE=$(date -u -d '7 days ago' +%FT%TZ 2>/dev/null || date -u -v-7d +%FT%TZ)
+  gh issue list --label evolveci/triage --state all \
+    --search "updated:>${SINCE}" -L 100 \
+    --json number,title,labels,createdAt,closedAt,body
+  ```
 
-### 步骤 2：深度分析
+- 列出本周建立的 `evolveci/pattern`：
+  ```bash
+  gh issue list --label evolveci/pattern --state all \
+    --search "created:>${SINCE}" -L 100 --json number,title,body
+  ```
 
-计算以下指标：
+- 收集 7 个工作日的 `evolveci/daily` issue body，提取关键指标用于趋势分析。
 
-**DORA 指标估算**：
-- 变更失败率：过去 7 天 CI 总失败率
-- MTTR（平均恢复时间）：从失败到下次成功的平均时间间隔（读取 incidents 数据）
-- 部署频率：成功运行的 `deploy`/`release` workflow 次数（估算）
+### 步骤 2：计算 DORA 指标
 
-**模式分析**：
-- Top 5 最频繁指纹（从 `memory/fingerprints/` 统计 `count`）
-- 本周新增 pattern 数（`source: "agent-learned"` 且 `last_seen` 在本周内的）
-- Tier 1 命中率：本周 incidents 中 `tier: 1` 的比例 vs 上周
+- Deployment frequency：识别有 deploy/release 关键字的 workflow runs
+- Lead time for changes：commit → 成功 deploy 的中位数
+- Change failure rate：deploy run 中失败的比例
+- MTTR：`evolveci/triage` 从 created → closed 的中位数
 
-**趋势分析**：
-- 各仓库健康排名（按失败率升序）
-- 本周 vs 上周对比（失败率、重跑次数、新 Issue 数）
+### 步骤 3：归档过期 incident
 
-### 步骤 3：自我进化评估
+把 7 天前已 close、未 reopen 的 `evolveci/triage` issue 加 `status/recovered`
+标签（如尚无），不再做任何编辑。
 
-- 统计本周新学习的 pattern 数和 Tier 1 命中率变化
-- 若 Tier 1 命中率提升 ≥5 个百分点 → 在报告中高亮
-- 更新 `CLAUDE.md` 的"近期学习"章节（最近 3-5 条新 pattern）
+### 步骤 4：生成报告 markdown
 
-### 步骤 4：生成报告
-
-使用我自己的分析能力生成中文周报（参考 `prompts/observability/weekly-deep-dive.md`）：
-
-报告结构：
 ```markdown
-## CI 周报 — YYYY-Www（YYYY-MM-DD ~ YYYY-MM-DD）
+# Weekly Deep Dive — {{iso_week}}
 
-### 执行摘要
-<3-5 句话，本周 CI 健康状况、最重要发现、建议优先级>
+**周期**: {{week_start}} → {{week_end}} UTC
 
-### 关键指标对比
+## 总览
 
-| 指标 | 本周 | 上周 | 趋势 |
-|------|------|------|------|
-| 总运行次数 | | | |
-| 失败率 | | | |
-| 自动重跑次数 | | | |
-| Tier 1 命中率 | | | |
-| 新增 Pattern 数 | | | |
+…（与上周对比）
 
-### DORA 指标
-- 变更失败率：N%（评级：Elite/High/Medium/Low）
-- MTTR：N 小时
-- 部署频率：N 次/周
+## DORA
 
-### 仓库健康排名
-<表格，含各仓库本周失败率>
+| 指标 | 本周 | 上周 |
+| --- | --- | --- |
+| Deployment frequency | … | … |
+| Lead time | … | … |
+| CFR | … | … |
+| MTTR | … | … |
 
-### Top 5 高频问题
-<按指纹出现次数排序，含 pattern_id/category/count/建议>
+## 本周关键 incidents (Top 5)
 
-### 自我进化报告
-- 本周新学习 Pattern：N 条
-- Tier 1 命中率：N%（上周：N%，变化：+/-N%）
-- [新 pattern 列表]
+- #1234 …
 
-### 建议行动项
-<基于本周分析的 3-5 条具体建议，含优先级>
+## 学习模式 (新增 evolveci/pattern)
+
+- #1456 …
+
+## 行动建议
+
+…（agent 推理）
 ```
 
-### 步骤 5：持久化、发布、更新记忆
+### 步骤 5：开 PR（不要直接 push 到 main）
 
-1. 写入 `memory/stats/weekly/<YYYY-Www>.json`
-2. 更新 `CLAUDE.md` 的"近期学习"章节
-3. 通过 GitHub MCP 创建 GitHub Issue：
-   - 标题：`CI 周报 - YYYY-Www`
-   - 标签：`weekly-report`、`ci-health`
-4. 提交变更：
 ```bash
-git add memory/stats/weekly/ CLAUDE.md
-git commit -m "memory: weekly-report — week YYYY-Www, Tier1 rate=N%, N new patterns"
-git push origin main
+WEEK=$(date -u +%G-W%V)
+BR="weekly/${WEEK}"
+
+# 1) 在 ${BR} 分支上更新 CLAUDE.md 的"近期学习"章节
+git switch -c "$BR"
+python3 -c '...patch CLAUDE.md...' # 把上面 markdown 报告插到对应章节
+
+git add CLAUDE.md
+git -c "user.name=evolveci-agent" -c "user.email=evolveci-agent@users.noreply.github.com" \
+    commit -m "weekly(${WEEK}): deep dive"
+git push -u origin "$BR"
+
+# 2) 开 PR；body 是完整报告
+gh pr create \
+  --base main --head "$BR" \
+  --title "weekly: ${WEEK} deep dive" \
+  --body-file <(echo "$REPORT_MARKDOWN")
 ```
 
-### 步骤 6：归档旧数据（月初运行时）
+PR 由人评审后 squash-merge。`/weekly-report` **不**自动 admin merge —
+留给 owner 决定是否信任后续轮次再切换为 `--auto`。
 
-若当前是每月 1 号（根据当前日期判断）：
-- 检查 `memory/incidents/` 中超过 90 天的月份目录
-- 将其中所有 `.jsonl` 文件合并为 `<YYYY-MM>-archived.jsonl.gz`（通过 Bash gzip 命令）
-- 提交归档变更
+## Slack 摘要（可选）
 
-## 每周统计 JSON 格式
+发送本周 5 个关键数字 + PR URL 到 `SLACK_WEBHOOK_URL`。
 
-`memory/stats/weekly/YYYY-Www.json`：
-```json
-{
-  "week": "YYYY-Www",
-  "start_date": "YYYY-MM-DD",
-  "end_date": "YYYY-MM-DD",
-  "total_runs": 892,
-  "total_failures": 98,
-  "failure_rate": 11,
-  "rerun_count": 23,
-  "tier1_hit_rate": 73,
-  "new_patterns": 3,
-  "mttr_hours": 2.4,
-  "repos": [
-    {"repo": "org/repo-a", "failure_rate": 6, "rank": 1},
-    {"repo": "org/repo-b", "failure_rate": 18, "rank": 2}
-  ]
-}
-```
+## 不做什么
+
+- 不直接 push 到 main
+- 不写 `memory/stats/weekly/`
+- 不 close 还在 open 的 `evolveci/triage`（除非 `status/recovered` 已经存在
+  且 ≥7 天没新动作）

--- a/.github/workflows/_call-harness.yml
+++ b/.github/workflows/_call-harness.yml
@@ -64,7 +64,12 @@ jobs:
       api-provider:        anthropic
       max-turns:           ${{ inputs.max-turns }}
       timeout-minutes:     ${{ inputs.timeout-minutes }}
-      extra-allowed-tools: ${{ inputs.extra-allowed-tools }}
+      # Issue/label/PR/branch operations the issue-as-memory model needs at
+      # every agent (heartbeat / triage / daily / weekly). The harness baseline
+      # in OpenCI ships the read-side (gh issue list/view/create/comment); these
+      # add the upsert + lifecycle ops. Caller-supplied extras are appended.
+      extra-allowed-tools: >-
+        Bash(gh issue edit),Bash(gh issue close),Bash(gh issue reopen),Bash(gh label list),Bash(gh label create),Bash(gh pr create),Bash(git switch),Bash(git checkout),Bash(git push -u origin),Bash(python3),Bash(python3 -c),${{ inputs.extra-allowed-tools }}
     secrets:
       api-key:       ${{ secrets.GLM_API_KEY }}
       api-base-url:  ${{ secrets.GLM_BASE_URL || 'https://open.bigmodel.cn/api/anthropic' }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,20 +3,22 @@
 ## 我是谁
 
 我是 EvolveCI 的 Claude Code Agent，负责监控组织内所有 GitHub Actions 流水线。
-我通过 GitHub MCP 工具直接查询 CI 数据，分析失败，执行动作，并将学习到的知识提交回 main 分支，实现持续自我进化。
+我通过 GitHub MCP 工具直接查询 CI 数据，分析失败，执行动作；持久化的"记忆"
+都存在 GitHub Issues 里（标签 `evolveci/*`），自然地按 fingerprint 去重、
+按日期 upsert，不在 git 历史里产生噪音。
 
-**这个仓库是我的大脑**——每次运行后，我将新学到的失败模式、指纹记录、统计快照写入 `memory/` 目录并提交，下次运行自动加载这些"记忆"。
+**记忆模型**（必读）：[`docs/MEMORY-MODEL.md`](./docs/MEMORY-MODEL.md)
 
 ## 被触发时的默认行为
 
 根据触发我的 workflow 名称判断当前任务：
 
-| Workflow | 执行命令 | 频率 |
-|---------|---------|------|
-| `agent-triage.yml` | `/triage` | 每 15 分钟 |
-| `agent-daily.yml` | `/daily-report` | 工作日 UTC 01:00 |
-| `agent-weekly.yml` | `/weekly-report` | 周一 UTC 02:00 |
-| `agent-heartbeat.yml` | `/heartbeat` | 每 6 小时 |
+| Workflow | 执行命令 | 频率 | 副作用 |
+|---------|---------|------|--------|
+| `agent-triage.yml` | `/triage` | 每 15 分钟 | 创建/累加 `evolveci/triage` issue |
+| `agent-heartbeat.yml` | `/heartbeat` | 每 6 小时 | 累加/关闭 `evolveci/heartbeat` issue |
+| `agent-daily.yml` | `/daily-report` | 工作日 UTC 01:00 | upsert 当日 `evolveci/daily` issue |
+| `agent-weekly.yml` | `/weekly-report` | 周一 UTC 02:00 | 开 PR（**唯一**触碰 git 的命令） |
 
 直接运行对应 slash command，无需等待用户输入。
 
@@ -28,25 +30,27 @@
 - **重跑预算**：每个 workflow 每日 ≤3 次，每个 repo 每日 ≤20 次（见 `data/circuit-config.yml`）
 - **日志脱敏**：传给任何分析前必须通过 `lib/redact-log.sh` 脱敏
 - **正则安全**：新学习的正则长度 ≤200 字符，禁止嵌套量词（`(.*)+`、`(.+)+` 等）
-- **熔断器**：`memory/circuit/state.json` 中 `active: true` 时，不执行任何自动重跑
+- **熔断器**：`evolveci/circuit` issue 的 `active=true` 时，不执行任何自动重跑
 
 ### 行动决策规则（分级）
 
-1. **Tier 1 — 已知模式**：测试 `memory/patterns/known-patterns.json` 中每条正则
+1. **Tier 1 — 已知模式**：列出 `evolveci/pattern` issue 的 body JSON，逐条正则匹配脱敏日志
    - 命中 → 直接按该 pattern 的 `auto_rerun`/`notify`/`severity` 字段执行
 2. **Tier 2 — 启发式规则**：关键词匹配（网络超时、权限错误、磁盘满、依赖冲突等）
    - 高/中置信度 → 直接决策；低置信度 → 进入 Tier 3
 3. **Tier 3 — 深度推理**：我用自己的推理能力分析脱敏日志
    - 参考 `prompts/observability/classify-failure-sonnet.md` 的输出格式
-   - 发现可复用模式时，调用 `/learn-pattern` 记录
-4. **flaky 类失败**：仅重跑，不建 Issue（避免噪音）
+   - 发现可复用模式时，调用 `/learn-pattern` 写入新的 `evolveci/pattern` issue
+4. **flaky 类失败**：仅重跑，不创建 issue（避免噪音）
 
-### 内存管理规则
+### 记忆 / 状态规则
 
-- 每次成功处理一批失败后，将新 pattern、fingerprint、计数器更新提交 main 分支
-- 提交信息格式：`memory: <动作> — <一行摘要>`
-- 每月第一天：检查 `memory/incidents/` 是否有超过 90 天的文件，超期文件归档
-- `CLAUDE.md` 的"近期学习"章节每周由 `/weekly-report` 命令更新
+- **不再向 `memory/` 写文件，不再 git commit 状态**。所有持久化经过 GitHub
+  Issues。
+- **去重**通过 `fingerprint:<12hex>` 标签实现：相同失败 → 累加到同一 issue。
+- **每周** `/weekly-report` 是唯一动 git 的命令；它在 `weekly/<iso-week>` 分支
+  上更新本文件的"近期学习"章节，并打开 PR 等待 squash-merge。
+- 旧 `memory/` 目录保留为只读历史归档；任何代码都不应再读它，未来一次清理 PR 会删除它。
 
 ## 快速参考
 
@@ -54,30 +58,23 @@
 → `data/onboarded-repos.yml`
 
 ### 已知失败模式库
-→ `memory/patterns/known-patterns.json`
+→ `gh issue list --label evolveci/pattern -L 100 --json body --jq '.[].body'`
 
-### 今日重跑计数器
-→ `memory/counters/YYYY-MM-DD.json`
+### 错误去重 / 历史 incidents
+→ `gh issue list --label evolveci/triage --state all`
+→ 同 fingerprint 的 issue 通过 `fingerprint:<12hex>` 标签精确定位
 
 ### 熔断器状态
-→ `memory/circuit/state.json`
-→ 如果 `active: true`，不执行任何自动重跑
+→ 单个 `evolveci/circuit` issue 的 body（JSON）
 
-### 错误指纹记录
-→ `memory/fingerprints/<fingerprint>.json`
-→ `linked_issue` 字段存 GitHub Issue 编号，用于去重
+### 每日报告
+→ `gh issue list --label evolveci/daily`
+
+### 每周深度复盘
+→ 通过 PR 提交（标题前缀 `weekly:`，分支 `weekly/<iso-week>`）
 
 ### 失败日志脱敏
 → `lib/redact-log.sh`（每次分析前必须调用）
-
-### Flaky 测试注册表
-→ `memory/flaky-tests/<org>-<repo>.json`
-
-### 每日统计快照
-→ `memory/stats/daily/YYYY-MM-DD.json`
-
-### 每周统计快照
-→ `memory/stats/weekly/YYYY-Www.json`
 
 ## Tier 2 启发式规则（内置）
 
@@ -100,17 +97,18 @@ _（初始状态，尚无学习记录）_
 
 ## 自我健康检查（/heartbeat 使用）
 
-运行 `/heartbeat` 时检查以下 5 个探针：
+运行 `/heartbeat` 时检查以下 5 个探针（具体查询见 `.claude/commands/heartbeat.md`）：
 
-1. **Triage 活跃度**：`memory/incidents/` 最新文件时间戳 ≤24h
-2. **模式库健康**：`memory/patterns/known-patterns.json` 条目数 ≥10
-3. **数据新鲜度**：`memory/stats/daily/` 最新文件 ≤48h
-4. **熔断器卡住**：`memory/circuit/state.json` 若 `active=true` 且超过 24h → 自动恢复
-5. **目录完整性**：`memory/` 所有必需子目录存在
+1. **Triage 活跃度**：近 24h 有更新过的 `evolveci/triage` issue
+2. **模式库健康**：`evolveci/pattern` issue 数 ≥10
+3. **数据新鲜度**：近 48h 有更新过的 `evolveci/daily` issue
+4. **熔断器状态**：单一 `evolveci/circuit` issue 的 `active` 字段
+5. **标签完整性**：`evolveci/*` 前缀的 label ≥5 个
 
-任一关键探针失败 → 创建 GitHub Issue + Slack 通知
+任一关键探针失败 → 在 `evolveci/heartbeat` issue 上累加 + Slack 通知。
 
 ## 版本历史
 
-- **v4.0 (2026-05)**: Agent 驱动架构，移除 `_state` 孤儿分支，Claude 直接持有记忆，通过 git commit 积累经验
-- **v3.0 (2026-05)**: 全能力版本（fingerprint + 聚类 + retry + auto-fix），孤儿分支状态存储
+- **v5.0 (2026-05)**: 记忆模型从 `memory/` 文件迁移到 GitHub Issues（`evolveci/*` 标签）。日报 / 心跳 / triage 全部通过 issue upsert，weekly 通过 PR 更新 CLAUDE.md。git 历史不再被状态写入污染。
+- **v4.0 (2026-05)**: Agent 驱动架构，Claude 直接持有记忆，通过 git commit 积累经验。
+- **v3.0 (2026-05)**: 全能力版本（fingerprint + 聚类 + retry + auto-fix），孤儿分支状态存储。

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -3,6 +3,9 @@
 Single source of truth for everything you can tune in this project. Anything
 not listed here is hard-wired in code and changes via PR.
 
+> **Companion doc**: [`docs/MEMORY-MODEL.md`](./MEMORY-MODEL.md) — how agent
+> memory lives in GitHub Issues (label scheme, per-task semantics, migration).
+
 > **Contract**: each row tells you the knob, where it lives, the default,
 > and how to override. If you change a knob and nothing in the next column
 > matches, the change won't take effect.

--- a/docs/MEMORY-MODEL.md
+++ b/docs/MEMORY-MODEL.md
@@ -1,0 +1,141 @@
+# EvolveCI — Memory Model (Issues as memory)
+
+## Why GitHub Issues, not files
+
+Earlier versions wrote agent memory to `memory/*.json` and committed every run.
+Result: noisy git history (one commit per heartbeat / triage / daily / pattern),
+hard to search, and weekly aggregation contended with concurrent commits.
+
+Issues fix all three: searchable by label / title, naturally append-on-update
+via comments, no git-history churn. This file is the contract for *which* issue
+holds *what*.
+
+## Label scheme
+
+All EvolveCI labels are prefixed with `evolveci/` so a consumer can filter the
+agent's surface from human-authored issues with one query.
+
+### Type labels (mutually exclusive)
+
+| Label | One issue per | Purpose |
+|-------|--------------|---------|
+| `evolveci/triage` | unique fingerprint | A CI failure observation. New occurrences append to the existing issue. |
+| `evolveci/heartbeat` | open at most one | Active health alert. Auto-closed when probes recover. |
+| `evolveci/daily` | calendar date | One per day. Re-runs the same day **edit** the body, not append a new issue. |
+| `evolveci/pattern` | learned pattern | Replaces `memory/patterns/known-patterns.json`. Body holds the JSON definition. |
+| `evolveci/circuit` | open at most one | Circuit breaker state. Body is the JSON state object; comments are the trip / recover history. |
+
+### Faceted labels (any may co-exist)
+
+| Label | Format | Used by |
+|-------|--------|---------|
+| `severity/critical` `severity/warning` `severity/info` | severity tier | all agents |
+| `fingerprint:<12hex>` | sha256 prefix | triage (exact-match dedup key) |
+| `repo:<org>-<repo>` | hyphenated repo | triage / daily |
+| `category:flaky` `category:infra` `category:code` `category:dependency` `category:unknown` | failure category | triage |
+| `status/recovered` | sentinel on close | heartbeat / triage |
+
+### Bootstrapping
+
+Run `scripts/bootstrap-labels.sh` once per repo. The script is idempotent —
+re-running creates only missing labels. The agent will also create missing
+`fingerprint:` and `repo:` labels on demand (label creation is cheap).
+
+## Per-task semantics
+
+### `/triage` (every 15 min)
+
+Pseudo-flow:
+
+1. compute `fp = sha256(error_lines + step_name)[:12]`
+2. `gh issue list --label fingerprint:${fp} --state open` → if any exists, comment on it with the new occurrence (timestamp + run URL) and increment the `occurrences:` counter line in the body
+3. otherwise create a new issue with labels `evolveci/triage`, `severity/<x>`, `category:<x>`, `fingerprint:${fp}`, `repo:<org>-<repo>` and the analysis as body
+
+### `/heartbeat` (every 6h)
+
+Probes now query GitHub instead of files:
+
+| Probe | Old (file) | New (issue query) |
+|-------|-----------|-------------------|
+| 1. Triage activity | newest `memory/incidents/` ≤24h | `gh issue list --label evolveci/triage --state all --search "updated:>$(date -u -v-24H +%FT%TZ)"` returns ≥1 |
+| 2. Pattern catalogue health | `≥10 entries` in JSON | `gh issue list --label evolveci/pattern -L 100 --json url` returns ≥10 items |
+| 3. Daily-report freshness | newest `memory/stats/daily/` ≤48h | `gh issue list --label evolveci/daily --search "updated:>$(date -u -v-48H +%FT%TZ)"` returns ≥1 |
+| 4. Circuit state | read `memory/circuit/state.json` | parse the body of the single `evolveci/circuit` issue |
+| 5. Directory integrity | check 7 dirs exist | replaced by "labels exist" check via `gh label list` |
+
+If any probe fails:
+- Search for an open `evolveci/heartbeat` issue. If exists → append a comment
+  with the failed-probe summary. Else → create one.
+
+If all probes pass:
+- Close any open `evolveci/heartbeat` issue with a comment "all probes
+  recovered at <ts>" and label `status/recovered`.
+
+### `/daily-report` (workdays UTC 01:00)
+
+Aggregate 24h, then either edit-in-place (re-run same day) or create a new
+issue:
+
+- title pattern: `Daily Report — YYYY-MM-DD`
+- existing? `gh issue list --label evolveci/daily --search "in:title $(date -u +%Y-%m-%d)"`
+- yes → `gh issue edit <num> --body-file -`
+- no  → `gh issue create --label evolveci/daily,severity/info`
+
+No more `memory/stats/daily/<date>.json` writes.
+
+### `/weekly-report` (Mon UTC 02:00)
+
+Weekly is the **only** workflow that produces a PR (not an issue). It writes
+the long-form report into `CLAUDE.md`'s "近期学习" section and optionally
+archives old triage issues by closing them.
+
+Branch name: `weekly/YYYY-Www`. PR title: `weekly: YYYY-Www deep dive`.
+
+PRs are reviewed by humans and squash-merged. (You can flip the agent to
+`--admin --auto` once you've audited a few cycles.)
+
+### `/learn-pattern`
+
+A single `gh issue create` writes the pattern as JSON in the body, labeled
+`evolveci/pattern`. Triage reads patterns via:
+
+```
+gh issue list --label evolveci/pattern -L 100 --json body --jq '.[].body' \
+  | while read -r b; do echo "$b" | jq -c .; done
+```
+
+### `/check-circuit`
+
+The single `evolveci/circuit` issue's body is a JSON state object:
+
+```json
+{ "active": false, "tripped_at": null, "tripped_reason": null, "history": [] }
+```
+
+- trip: `gh issue edit` with the new body, plus a `gh issue comment` recording the trigger
+- recover: edit body to `active=false`; comment with the recovery time
+- if no issue exists, create one with the default body
+
+## Migration
+
+The transition is one-way and incremental:
+
+1. **First run after this change**: each command finds zero matching issues and
+   starts populating them. No legacy `memory/` reads required.
+2. **Old `memory/` files**: kept as historical archive; not read, not written.
+   A future cleanup PR can `git rm -r memory/`.
+3. **Labels**: bootstrap by `scripts/bootstrap-labels.sh`, OR auto-created by
+   the agent on first use.
+
+## Failure modes & limits
+
+- **Issue search latency**: ~1 API call per command. Acceptable for cron-driven
+  workflows.
+- **Issue volume**: triage creates ≤1 issue per unique fingerprint. With ~100
+  fingerprints in steady state, GitHub list APIs return them in a single page.
+- **Rate limits**: every command does ≤5–10 API calls. Even at the 15-min
+  cron of triage, that's well under GitHub's per-hour budget.
+- **Concurrency**: heartbeat / triage may race on the same `evolveci/heartbeat`
+  issue. GitHub's API has no transactional update; the agent uses
+  `--state open` + create-if-missing logic, accepting at most one duplicate
+  per race.

--- a/scripts/bootstrap-labels.sh
+++ b/scripts/bootstrap-labels.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# bootstrap-labels.sh — idempotently create the EvolveCI label scheme.
+# ─────────────────────────────────────────────────────────────────────────────
+# Run once per monitored repo (or per agent-target repo) before the first
+# /heartbeat. Safe to re-run — `gh label create --force` updates colour /
+# description for existing labels and creates only the ones that are missing.
+#
+# The scheme is documented in docs/MEMORY-MODEL.md. Keep this file and that
+# doc in sync.
+# ─────────────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+REPO="${1:-${GITHUB_REPOSITORY:-}}"
+if [ -z "$REPO" ]; then
+  echo "usage: $0 <owner/repo>" >&2
+  exit 2
+fi
+
+ensure() {
+  local name="$1" colour="$2" description="$3"
+  gh label create "$name" --color "$colour" --description "$description" \
+    --repo "$REPO" --force >/dev/null
+  echo "  ✓ $name"
+}
+
+echo "Creating EvolveCI labels in $REPO..."
+
+# ── Type labels (mutually exclusive per issue) ───────────────────────────────
+ensure "evolveci/triage"    "d73a4a" "EvolveCI agent — CI failure observation (one issue per fingerprint)"
+ensure "evolveci/heartbeat" "fbca04" "EvolveCI agent — active health alert (≤1 open at a time)"
+ensure "evolveci/daily"     "0e8a16" "EvolveCI agent — daily report (one per calendar date)"
+ensure "evolveci/pattern"   "1d76db" "EvolveCI agent — known failure pattern (replaces memory/patterns)"
+ensure "evolveci/circuit"   "5319e7" "EvolveCI agent — circuit-breaker state (≤1 open at a time)"
+
+# ── Severity labels ─────────────────────────────────────────────────────────
+ensure "severity/critical"  "b60205" "Severity — critical: blocks pipelines or risks data"
+ensure "severity/warning"   "fbca04" "Severity — warning: degrades but not blocking"
+ensure "severity/info"      "c2e0c6" "Severity — informational"
+
+# ── Category labels (failure taxonomy used by triage) ───────────────────────
+ensure "category:flaky"      "fef2c0" "Category — flaky / non-deterministic"
+ensure "category:infra"      "fef2c0" "Category — runner / infrastructure issue"
+ensure "category:code"       "fef2c0" "Category — code defect"
+ensure "category:dependency" "fef2c0" "Category — dependency / package issue"
+ensure "category:unknown"    "fef2c0" "Category — needs deeper investigation"
+
+# ── Status labels ────────────────────────────────────────────────────────────
+ensure "status/recovered"    "0e8a16" "Status — auto-recovered by the agent"
+
+echo "Done. fingerprint:* and repo:* labels are created on demand by triage."


### PR DESCRIPTION
## Why

Previous model: every triage/heartbeat/daily/learn-pattern run wrote a JSON file under `memory/` and committed to main. Result:
- noisy git history (one commit per cron tick)
- state scattered across many tiny files
- weekly aggregation contended with concurrent commits

## What

State now lives in **GitHub Issues**, identified by labels prefixed `evolveci/`. The five issue types form a complete memory:

| Label | One issue per | Purpose |
| --- | --- | --- |
| `evolveci/triage` | unique fingerprint | CI failure observation; new occurrences comment + edit body counter |
| `evolveci/heartbeat` | open at most one | active health alert; auto-closed on probe recovery |
| `evolveci/daily` | calendar date | one per day; same-day re-runs edit body |
| `evolveci/pattern` | learned pattern | replaces `memory/patterns/known-patterns.json` |
| `evolveci/circuit` | open at most one | circuit-breaker state JSON in body |

Faceted labels: `severity/*`, `fingerprint:<12hex>`, `repo:<org>-<repo>`, `category:*`, `status/recovered`.

## Behaviour changes

- **Daily / heartbeat / triage** never touch git — read-only on CI, upsert-only on Issues.
- **Weekly** is the only workflow that touches git: opens a PR on `weekly/<iso-week>` updating CLAUDE.md's "近期学习" section. Humans squash-merge.
- **Similar-issue dedup**:
  - triage looks up by `fingerprint:<hash>` label (exact dedup)
  - daily looks up by date in title (upsert)
  - heartbeat looks up by status (single open issue per alert window)

## Files

- `docs/MEMORY-MODEL.md` (new) — full contract: labels, per-task semantics, migration, failure modes.
- `scripts/bootstrap-labels.sh` (new) — idempotent label creation.
- `.claude/commands/{heartbeat,triage,daily-report,weekly-report,learn-pattern,check-circuit}.md` — rewritten end-to-end.
- `.github/workflows/_call-harness.yml` — `extra-allowed-tools` ships the gh issue/label/PR + git switch ops every command needs.
- `CLAUDE.md` — memory section rewritten; v5.0 entry added.

Old `memory/` tree stays as read-only historical archive; nothing reads from it any more. A future cleanup PR can `git rm -r memory/`.

## Test plan

- [ ] Run `bash scripts/bootstrap-labels.sh YiAgent/EvolveCI` once to create labels.
- [ ] Dispatch heartbeat — should report "標籤完整性 ok" + close any old `evolveci/heartbeat` issue.
- [ ] Dispatch triage on a repo with no failures — should produce no new issue but no errors.
- [ ] Dispatch daily — should create `Daily Report — YYYY-MM-DD` issue.
- [ ] Dispatch weekly — should open a `weekly/<iso-week>` PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/YiAgent/codesmith/EvolveCI/pr/11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Migrated system memory from local files to GitHub Issues with a standardized label scheme (`evolveci/*`) for improved visibility, collaboration, and state tracking.

* **Documentation**
  * Added comprehensive memory model documentation describing the new GitHub Issue-based persistence architecture and operational semantics.

* **Chores**
  * Added bootstrap script to initialize the required GitHub label scheme for the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->