### PR TITLE
fix(heartbeat): raise turn budget for issue-based probes

### DIFF
--- a/.github/workflows/agent-heartbeat.yml
+++ b/.github/workflows/agent-heartbeat.yml
@@ -27,6 +27,6 @@ jobs:
     with:
       task: heartbeat
       prompt: /heartbeat
-      max-turns: 15
-      timeout-minutes: 10
+      max-turns: 25
+      timeout-minutes: 15
     secrets: inherit

--- a/docs/harness-rollout-log.md
+++ b/docs/harness-rollout-log.md
@@ -155,3 +155,22 @@ prompts.
 | EvolveCI | #6  | route agent workflows via the refactored harness using GLM Coding Plan |
 | EvolveCI | #7  | grant the permissions the harness reusable workflow declares (actions:read, id-token:write, pull-requests:write) |
 | EvolveCI | #8  | raise daily/weekly turn budgets to 40/50; bump timeouts to 25/35 min |
+
+---
+
+## Phase 2 — Issues-as-memory rollout (2026-05-02 ~03:22 UTC)
+
+PR #10 (config unification) and PR #11 (memory→issues) both merged.
+
+### Op 15 — bootstrap labels
+
+`bash scripts/bootstrap-labels.sh YiAgent/EvolveCI` created the 14 baseline labels: 5 type labels (`evolveci/triage` etc.), 3 severity, 5 category, 1 status. fingerprint:* and repo:* labels are created on demand by triage.
+
+### Op 16 — dispatch all 4 workflows on memory-as-issues main
+
+- heartbeat: 25242583392
+- triage:    25242583918
+- daily:     25242584347
+- weekly:    25242584801
+
+Pending — waiting on background monitor.


### PR DESCRIPTION
Run 25242583392 hit 'Reached maximum number of turns (15)' on the new memory model. Each probe is now ≥1 tool call (gh issue list/view) instead of a file read, plus create/comment/close path. Bump max-turns 15→25, timeout 10→15 min.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/YiAgent/codesmith/EvolveCI/pr/12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved workflow performance parameters for enhanced processing capacity and stability.

* **Documentation**
  * Updated rollout tracking documentation with Phase 2 status and initialization steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->