### PR TITLE
fix(weekly): raise turn budget for issue-aggregation + PR flow

### DIFF
--- a/.github/workflows/agent-weekly.yml
+++ b/.github/workflows/agent-weekly.yml
@@ -27,6 +27,6 @@ jobs:
     with:
       task: weekly-report
       prompt: /weekly-report
-      max-turns: 50
-      timeout-minutes: 35
+      max-turns: 80
+      timeout-minutes: 50
     secrets: inherit


### PR DESCRIPTION
Run 25242584801 hit max-turns=50 on the issue-based weekly. Bump to 80 / 50 min.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/YiAgent/codesmith/EvolveCI/pr/13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated weekly report generation configuration to increase processing capacity and execution time limits, allowing for more comprehensive analysis during scheduled weekly runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->