### PR TITLE
chore(monitoring): onboard real YiAgent repos

### DIFF
--- a/data/onboarded-repos.yml
+++ b/data/onboarded-repos.yml
@@ -1,15 +1,20 @@
+# EvolveCI 监控的仓库列表（agent /triage / /daily / /weekly 都会读它）.
+#
+# 字段:
+#   name:      org/repo
+#   workflows: "*" 表示所有 workflow；或逗号分隔的 yml 文件名
+#   priority:  high | low (high 优先级仓库会先处理)
+#   exclude:   排除特定 workflow 文件名（数组）
 repos:
-  - name: org/repo-a
-    workflows: "*"
-    priority: high
-
-  - name: org/repo-b
-    workflows: "pr.yml,ci.yml"
-    priority: low
-
-  - name: org/repo-c
+  - name: YiAgent/EvolveCI
     workflows: "*"
     priority: high
     exclude:
-      - "stale.yml"
-      - "community.yml"
+      - "agent-heartbeat.yml"
+      - "agent-triage.yml"
+      - "agent-daily.yml"
+      - "agent-weekly.yml"
+
+  - name: YiAgent/OpenCI
+    workflows: "*"
+    priority: high


### PR DESCRIPTION
Placeholder repos returned 404 on every CI query → agents skipped issue creation. Switch to YiAgent/EvolveCI + YiAgent/OpenCI; EvolveCI excludes its own agent workflows to avoid self-monitoring loops.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/YiAgent/codesmith/EvolveCI/pr/14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated repository onboarding configuration to register YiAgent/EvolveCI and YiAgent/OpenCI for workflow processing at high priority.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->