### PR TITLE
fix(prompts): mandatory daily/weekly artifacts; auto-seed pattern catalogue

### DIFF
--- a/.claude/commands/daily-report.md
+++ b/.claude/commands/daily-report.md
@@ -5,6 +5,17 @@
 > 内存模型：每天一个 `evolveci/daily` Issue。同日重跑 → 编辑 body 而非新建。
 > 详见 `docs/MEMORY-MODEL.md`。
 
+## ⚠️ 强制契约（不可违反）
+
+**每次运行必须以 `gh issue create` 或 `gh issue edit` 结束**——即使 24 小时内
+没有任何数据可报告。这是任务的**成功条件**：没有 issue 写入 = 任务失败，
+即使所有命令都执行了。
+
+如果发现完全没有 CI 数据：
+- 仍然创建当日的 `evolveci/daily` Issue
+- Body 写明 "no_data: true"，并简要说明检查了哪些仓库、为什么没有数据
+- 这本身就是有用信号（说明 CI 静默或仓库列表配置有问题）
+
 ## 执行步骤
 
 ### 步骤 1：聚合最近 24 小时数据
@@ -26,23 +37,23 @@ PREV=$(gh issue list --label evolveci/daily -L 5 --json number,title,body \
         --jq '.[] | select(.title | startswith("Daily Report — "))')
 ```
 
-取前一份与当前的关键指标对比，标出 ≥20% 的劣化项。
+取前一份与当前的关键指标对比，标出 ≥20% 的劣化项。如果没有 PREV，跳过此步。
 
-### 步骤 3：在 issue 上 upsert
+### 步骤 3：在 issue 上 upsert（必做）
 
 ```bash
 TODAY=$(date -u +%Y-%m-%d)
 TITLE="Daily Report — ${TODAY}"
 
-# 是否已有今天的 issue？通过标题前缀搜索（in:title）
 EXISTING=$(gh issue list --label evolveci/daily \
             --search "in:title \"${TITLE}\"" -L 1 \
             --json number --jq '.[0].number // empty')
 
-REPORT_BODY=$(render-report)  # 渲染 markdown 报告
+REPORT_BODY=$(render-report)  # 渲染下面那块 markdown
 
 if [ -n "$EXISTING" ]; then
   gh issue edit "$EXISTING" --body "$REPORT_BODY"
+  echo "Updated daily issue #$EXISTING"
 else
   gh issue create \
     --title "$TITLE" \
@@ -61,6 +72,7 @@ fi
 # Daily Report — {{today}}
 
 **生成时间**: {{generated_at}} UTC
+**监控仓库**: {{repos_count}} 个（详见 data/onboarded-repos.yml）
 
 ## 总览
 
@@ -76,9 +88,11 @@ fi
 - #1234 `repo · workflow · step` (severity/critical, category:infra)
 - #1235 …
 
+（若无：`_当日无新增 triage issue。_`）
+
 ## 仍 open 的 triage（>24h）
 
-…
+…（若无：`_无超期 triage issue。_`）
 
 ## 学习
 
@@ -86,6 +100,19 @@ fi
 - auto-rerun 触发 × N
 - 熔断器状态：active=…
 ```
+
+如果完全无数据，body 写：
+
+```markdown
+# Daily Report — {{today}}
+
+**生成时间**: {{generated_at}} UTC
+**no_data**: true
+
+检查了仓库 {{repos_list}}，过去 24 小时内没有 workflow runs。可能原因：
+- 仓库配置有误（请检查 data/onboarded-repos.yml）
+- CI 在静默期（节假日、冻结）
+- API token 权限不足以读取 actions
 
 ## 不做什么
 

--- a/.claude/commands/heartbeat.md
+++ b/.claude/commands/heartbeat.md
@@ -22,13 +22,32 @@ COUNT=$(gh issue list --label evolveci/triage --state all \
 
 `COUNT == 0` → **失败**：triage 超过 24 小时未运行。
 
-### 探针 2：模式库健康（关键）
+### 探针 2：模式库健康（关键 + 自愈）
 
 ```bash
 COUNT=$(gh issue list --label evolveci/pattern --state all -L 100 --json number | jq length)
 ```
 
-`COUNT < 10` → **失败**：模式库条目过少（首次运行后应已从 `data/known-patterns.seed.json` 种入）。
+如果 `COUNT == 0`（首次运行）：**自动从 `data/known-patterns.seed.json`
+种入**——为每条 seed 创建一个 `evolveci/pattern` Issue，body 是该 seed 的 JSON：
+
+```bash
+if [ "$COUNT" = "0" ] && [ -f data/known-patterns.seed.json ]; then
+  jq -c '.[]' data/known-patterns.seed.json | while read -r p; do
+    ID=$(echo "$p" | jq -r .id)
+    SEV=$(echo "$p" | jq -r '.severity // "info"')
+    CAT=$(echo "$p" | jq -r '.category // "unknown"')
+    gh issue create \
+      --title "pattern: ${ID}" \
+      --label "evolveci/pattern,severity/${SEV},category:${CAT}" \
+      --body "$p"
+  done
+  COUNT=$(jq length data/known-patterns.seed.json)
+fi
+```
+
+种入后 `COUNT < 10` → **失败**：模式库条目过少（seed 文件可能损坏）。
+否则 → **PASS**。
 
 ### 探针 3：统计数据新鲜度（警告）
 

--- a/.claude/commands/weekly-report.md
+++ b/.claude/commands/weekly-report.md
@@ -6,6 +6,18 @@
 > 的"近期学习"章节，并打开一个 PR 等待 squash-merge。日报 / 心跳 / triage
 > 全部走 Issue。详见 `docs/MEMORY-MODEL.md`。
 
+## ⚠️ 强制契约（不可违反）
+
+**每次运行必须以 `gh pr create` 结束**——即使本周没有任何 incident 或新模式。
+这是任务的**成功条件**：没有 PR 提交 = 任务失败，即使所有命令都执行了。
+
+如果完全没有数据：
+- 仍然创建 `weekly/<iso-week>` 分支并打开 PR
+- PR body 标注 "no_data: true" 并解释检查了哪些数据源
+- CLAUDE.md 的"近期学习"章节追加一行 `YYYY-MM-DD: _本周无新模式_`
+
+只有这种"无声 PR"才会让我们及时发现"agent 跑了但啥也没做"的死循环。
+
 ## 执行步骤
 
 ### 步骤 1：聚合 7 天数据
@@ -44,6 +56,7 @@
 # Weekly Deep Dive — {{iso_week}}
 
 **周期**: {{week_start}} → {{week_end}} UTC
+**监控仓库**: {{repos_list}}
 
 ## 总览
 
@@ -71,22 +84,35 @@
 …（agent 推理）
 ```
 
-### 步骤 5：开 PR（不要直接 push 到 main）
+无数据时的 body：
+
+```markdown
+# Weekly Deep Dive — {{iso_week}}
+
+**no_data**: true
+
+本周（{{week_start}} → {{week_end}}）没有新增 incident、新模式或 daily-report。
+原因可能是：
+- agent 系统刚上线，尚未积累数据
+- 监控仓库当周静默
+- 配置异常（请检查 data/onboarded-repos.yml）
+```
+
+### 步骤 5：开 PR（不要直接 push 到 main，必做）
 
 ```bash
 WEEK=$(date -u +%G-W%V)
 BR="weekly/${WEEK}"
 
-# 1) 在 ${BR} 分支上更新 CLAUDE.md 的"近期学习"章节
 git switch -c "$BR"
-python3 -c '...patch CLAUDE.md...' # 把上面 markdown 报告插到对应章节
+# 在 CLAUDE.md "近期学习"章节追加一行：YYYY-MM-DD: <模式 id> — <一句话>
+# 无新模式 → 追加：YYYY-MM-DD: _本周无新模式_
 
 git add CLAUDE.md
 git -c "user.name=evolveci-agent" -c "user.email=evolveci-agent@users.noreply.github.com" \
     commit -m "weekly(${WEEK}): deep dive"
 git push -u origin "$BR"
 
-# 2) 开 PR；body 是完整报告
 gh pr create \
   --base main --head "$BR" \
   --title "weekly: ${WEEK} deep dive" \


### PR DESCRIPTION
Daily ran 24 turns, weekly ran 50, both 'success', neither produced an artifact. Make the issue/PR creation mandatory in the prompts and have heartbeat self-seed patterns from data/known-patterns.seed.json when the catalogue is empty (zero on first install).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/YiAgent/codesmith/EvolveCI/pr/17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Daily and weekly reports now reliably execute and create documentation even when no new data is available

* **New Features**
  * Pattern library now auto-recovers from empty state using seed data
  * Monitoring enhanced with repository count tracking in reports

<!-- end of auto-generated comment: release notes by coderabbit.ai -->