### PR TITLE
fix(seed): extract pattern seeding into scripts/seed-patterns.sh

### DIFF
--- a/.claude/commands/heartbeat.md
+++ b/.claude/commands/heartbeat.md
@@ -28,26 +28,16 @@ COUNT=$(gh issue list --label evolveci/triage --state all \
 COUNT=$(gh issue list --label evolveci/pattern --state all -L 100 --json number | jq length)
 ```
 
-如果 `COUNT == 0`（首次运行）：**自动从 `data/known-patterns.seed.json`
-种入**——为每条 seed 创建一个 `evolveci/pattern` Issue，body 是该 seed 的 JSON：
+如果 `COUNT == 0` → **必须立即执行**（不是示例代码，不要跳过）：
 
 ```bash
-if [ "$COUNT" = "0" ] && [ -f data/known-patterns.seed.json ]; then
-  jq -c '.[]' data/known-patterns.seed.json | while read -r p; do
-    ID=$(echo "$p" | jq -r .id)
-    SEV=$(echo "$p" | jq -r '.severity // "info"')
-    CAT=$(echo "$p" | jq -r '.category // "unknown"')
-    gh issue create \
-      --title "pattern: ${ID}" \
-      --label "evolveci/pattern,severity/${SEV},category:${CAT}" \
-      --body "$p"
-  done
-  COUNT=$(jq length data/known-patterns.seed.json)
-fi
+bash scripts/seed-patterns.sh "$GITHUB_REPOSITORY"
 ```
 
-种入后 `COUNT < 10` → **失败**：模式库条目过少（seed 文件可能损坏）。
-否则 → **PASS**。
+该脚本是幂等的：如果已经有任何 `evolveci/pattern` Issue 存在，它会立即跳过；
+否则把 `data/known-patterns.seed.json` 全部种入为 Issue。运行后再次查询 COUNT。
+
+`COUNT < 10` → **失败**：种入失败或 seed 文件损坏。否则 → **PASS**。
 
 ### 探针 3：统计数据新鲜度（警告）
 

--- a/.github/workflows/_call-harness.yml
+++ b/.github/workflows/_call-harness.yml
@@ -69,7 +69,7 @@ jobs:
       # in OpenCI ships the read-side (gh issue list/view/create/comment); these
       # add the upsert + lifecycle ops. Caller-supplied extras are appended.
       extra-allowed-tools: >-
-        Bash(gh issue edit),Bash(gh issue close),Bash(gh issue reopen),Bash(gh label list),Bash(gh label create),Bash(gh pr create),Bash(git switch),Bash(git checkout),Bash(git push -u origin),Bash(python3),Bash(python3 -c),${{ inputs.extra-allowed-tools }}
+        Bash(gh issue edit),Bash(gh issue close),Bash(gh issue reopen),Bash(gh label list),Bash(gh label create),Bash(gh pr create),Bash(git switch),Bash(git checkout),Bash(git push -u origin),Bash(python3),Bash(python3 -c),Bash(bash scripts/),${{ inputs.extra-allowed-tools }}
     secrets:
       api-key:       ${{ secrets.GLM_API_KEY }}
       api-base-url:  ${{ secrets.GLM_BASE_URL || 'https://open.bigmodel.cn/api/anthropic' }}

--- a/scripts/seed-patterns.sh
+++ b/scripts/seed-patterns.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# seed-patterns.sh — port data/known-patterns.seed.json into evolveci/pattern
+#                    Issues. Idempotent: skipped entirely if any
+#                    evolveci/pattern issue already exists.
+# ─────────────────────────────────────────────────────────────────────────────
+# Run by /heartbeat probe 2 when the catalogue is empty. Safe to run by hand:
+#   bash scripts/seed-patterns.sh YiAgent/EvolveCI
+#
+# Outputs one JSON line per created pattern + a final summary line.
+# ─────────────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+REPO="${1:-${GITHUB_REPOSITORY:-}}"
+SEED_FILE="${2:-data/known-patterns.seed.json}"
+
+if [ -z "$REPO" ]; then
+  echo "usage: $0 <owner/repo> [seed-json-path]" >&2
+  exit 2
+fi
+if [ ! -f "$SEED_FILE" ]; then
+  echo "seed file not found: $SEED_FILE" >&2
+  exit 2
+fi
+
+# Idempotency check — skip when any pattern issue already exists.
+EXISTING=$(gh issue list --repo "$REPO" --label evolveci/pattern --state all -L 1 \
+  --json number --jq 'length')
+if [ "$EXISTING" -gt 0 ]; then
+  echo "{\"status\":\"skipped\",\"reason\":\"$EXISTING evolveci/pattern issues already exist\"}"
+  exit 0
+fi
+
+CREATED=0
+TOTAL=$(jq length "$SEED_FILE")
+echo "{\"status\":\"seeding\",\"total\":$TOTAL,\"repo\":\"$REPO\"}"
+
+# Iterate over each pattern in the seed file.
+jq -c '.[]' "$SEED_FILE" | while IFS= read -r pattern; do
+  ID=$(echo "$pattern"   | jq -r .id)
+  RAW_SEV=$(echo "$pattern"  | jq -r '.severity // "info"')
+  CAT=$(echo "$pattern"  | jq -r '.category // "unknown"')
+
+  # Normalise seed-file severity (low / medium / high) into the bootstrap
+  # label scheme (info / warning / critical).
+  case "$RAW_SEV" in
+    low)            SEV="info" ;;
+    medium|warning) SEV="warning" ;;
+    high|critical)  SEV="critical" ;;
+    *)              SEV="info" ;;
+  esac
+
+  if [ -z "$ID" ] || [ "$ID" = "null" ]; then
+    echo "{\"status\":\"warn\",\"reason\":\"pattern missing id\",\"pattern\":$pattern}" >&2
+    continue
+  fi
+
+  # category: label uses category:foo (with colon), already created by bootstrap
+  # severity/info etc., already created by bootstrap. We only auto-create
+  # category labels we don't recognise.
+  case "$CAT" in
+    flaky|infra|code|dependency|unknown) ;;
+    *)
+      gh label create "category:$CAT" --color "fef2c0" \
+        --description "Failure category" --force --repo "$REPO" >/dev/null
+      ;;
+  esac
+
+  URL=$(gh issue create \
+    --repo "$REPO" \
+    --title "pattern: $ID" \
+    --label "evolveci/pattern,severity/$SEV,category:$CAT" \
+    --body "$pattern")
+  CREATED=$((CREATED + 1))
+  echo "{\"status\":\"created\",\"id\":\"$ID\",\"severity\":\"$SEV\",\"category\":\"$CAT\",\"url\":\"$URL\"}"
+done
+
+# (Final summary line — outer loop variable doesn't survive the pipe in bash,
+# so re-count from the API.)
+FINAL=$(gh issue list --repo "$REPO" --label evolveci/pattern --state all -L 200 \
+  --json number --jq 'length')
+echo "{\"status\":\"done\",\"created\":$FINAL,\"expected\":$TOTAL}"


### PR DESCRIPTION
Make heartbeat's seed logic a real script (idempotent, observable JSON output) so the agent has to make one bash call rather than parse inline pseudo-code. Pre-merge bootstrap already done — 10 pattern issues #18–#27 exist.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/YiAgent/codesmith/EvolveCI/pr/28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pattern library seeding process to use a dedicated script with improved reliability and idempotency checks
  * Updated CI/CD workflow configuration to support enhanced script execution capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->