### PR TITLE
fix(daily): raise turn budget for imperative report flow

### DIFF
--- a/.github/workflows/agent-daily.yml
+++ b/.github/workflows/agent-daily.yml
@@ -27,6 +27,6 @@ jobs:
     with:
       task: daily-report
       prompt: /daily-report
-      max-turns: 40
-      timeout-minutes: 25
+      max-turns: 60
+      timeout-minutes: 30
     secrets: inherit


### PR DESCRIPTION
Run 25243111528 hit max-turns=40 with the new mandatory-artifact contract (PR #17). Bump 40→60, timeout 25→30.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/YiAgent/codesmith/EvolveCI/pr/29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow parameters to improve reliability and performance of automated processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->