### PR TITLE
fix(prompts+scripts): heartbeat 强制契约 + weekly-pr.sh helper + 120-turn weekly

### DIFF
--- a/.claude/commands/heartbeat.md
+++ b/.claude/commands/heartbeat.md
@@ -5,10 +5,22 @@
 > 内存模型：所有持久化状态都存放在带 `evolveci/*` 前缀标签的 Issue 中。
 > 详见 `docs/MEMORY-MODEL.md`。
 
+## ⚠️ 强制契约（不可违反）
+
+每次运行**必须**以下面两种动作之一结束：
+
+1. **任一关键探针失败时** — 必须执行 `gh issue comment` 或 `gh issue create`
+   往 `evolveci/heartbeat` 标签的 Issue 上写入本轮 5 个探针的结果。
+2. **全部通过时** — 必须执行 `gh issue close` 关闭任何尚处 open 的
+   `evolveci/heartbeat` Issue（带恢复 comment + `status/recovered` 标签）。
+
+不允许"探针都跑完了但什么都没写"。这是任务的成功条件——没有 issue 写入或
+close = 任务失败，即使所有命令都执行了。**下方的 bash 代码是你必须执行的
+命令，不是示例。**
+
 ## 执行步骤
 
-依次执行以下 5 个探针，任一关键探针失败 → 在 `evolveci/heartbeat` Issue 上累加；
-全部通过 → 关闭任何尚处 open 的 `evolveci/heartbeat` Issue。
+依次执行以下 5 个探针，最后**根据强制契约写 issue**。
 
 ### 探针 1：Triage 活跃度（关键）
 

--- a/.claude/commands/weekly-report.md
+++ b/.claude/commands/weekly-report.md
@@ -100,24 +100,24 @@
 
 ### 步骤 5：开 PR（不要直接 push 到 main，必做）
 
+把渲染好的 markdown 报告写入文件，把"近期学习"那一行准备好，调用辅助脚本：
+
 ```bash
-WEEK=$(date -u +%G-W%V)
-BR="weekly/${WEEK}"
+# 1. 写入报告 markdown
+echo "$REPORT_MARKDOWN" > /tmp/weekly-report.md
 
-git switch -c "$BR"
-# 在 CLAUDE.md "近期学习"章节追加一行：YYYY-MM-DD: <模式 id> — <一句话>
-# 无新模式 → 追加：YYYY-MM-DD: _本周无新模式_
+# 2. 准备 CLAUDE.md 的学习行（无新模式时用占位）
+LEARNING="$(date -u +%Y-%m-%d): <pattern-id> — <一句话>"
+# 或：
+# LEARNING="$(date -u +%Y-%m-%d): _本周无新模式_"
 
-git add CLAUDE.md
-git -c "user.name=evolveci-agent" -c "user.email=evolveci-agent@users.noreply.github.com" \
-    commit -m "weekly(${WEEK}): deep dive"
-git push -u origin "$BR"
-
-gh pr create \
-  --base main --head "$BR" \
-  --title "weekly: ${WEEK} deep dive" \
-  --body-file <(echo "$REPORT_MARKDOWN")
+# 3. 一行执行：分支创建 + CLAUDE.md 编辑 + commit + push + 开 PR
+bash scripts/weekly-pr.sh \
+  --report-file /tmp/weekly-report.md \
+  --learning-line "$LEARNING"
 ```
+
+脚本输出一行 JSON `{"status":"ok","branch":"...","pr":"...","week":"..."}`。
 
 PR 由人评审后 squash-merge。`/weekly-report` **不**自动 admin merge —
 留给 owner 决定是否信任后续轮次再切换为 `--auto`。

--- a/.github/workflows/agent-weekly.yml
+++ b/.github/workflows/agent-weekly.yml
@@ -27,6 +27,6 @@ jobs:
     with:
       task: weekly-report
       prompt: /weekly-report
-      max-turns: 80
-      timeout-minutes: 50
+      max-turns: 120
+      timeout-minutes: 70
     secrets: inherit

--- a/scripts/weekly-pr.sh
+++ b/scripts/weekly-pr.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# weekly-pr.sh — open a `weekly: <iso-week> deep dive` PR.
+# ─────────────────────────────────────────────────────────────────────────────
+# Designed for /weekly-report: cuts ~10 turns of git fiddling into one bash
+# call. The agent only has to:
+#   1. render its markdown report
+#   2. compute the one-line CLAUDE.md update
+#   3. invoke this script with both as inputs
+#
+# Usage:
+#   bash scripts/weekly-pr.sh \
+#     --report-file /tmp/weekly-report.md \
+#     --learning-line "2026-05-02: _no new patterns this week_"
+#
+# Outputs (one JSON line):
+#   {"status":"ok","branch":"weekly/2026-W18","pr":"https://...","week":"2026-W18"}
+# ─────────────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+REPORT_FILE=""
+LEARNING_LINE=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --report-file)   REPORT_FILE="$2"; shift 2 ;;
+    --learning-line) LEARNING_LINE="$2"; shift 2 ;;
+    *) echo "unknown flag: $1" >&2; exit 2 ;;
+  esac
+done
+
+[ -n "$REPORT_FILE" ]   || { echo "--report-file required" >&2; exit 2; }
+[ -f "$REPORT_FILE" ]   || { echo "report file not found: $REPORT_FILE" >&2; exit 2; }
+[ -n "$LEARNING_LINE" ] || { echo "--learning-line required" >&2; exit 2; }
+
+WEEK=$(date -u +%G-W%V)
+BR="weekly/${WEEK}"
+
+# Configure git identity for the agent's commit.
+git config user.name  "evolveci-agent"
+git config user.email "evolveci-agent@users.noreply.github.com"
+
+# Branch off main.
+git fetch origin main --quiet
+git switch -c "$BR" origin/main
+
+# Append the learning line under the "## 近期学习" header in CLAUDE.md.
+python3 - "$LEARNING_LINE" <<'PY'
+import sys, pathlib
+line = sys.argv[1]
+p = pathlib.Path("CLAUDE.md")
+text = p.read_text()
+marker = "## 近期学习（由 /weekly-report 维护）"
+if marker not in text:
+    raise SystemExit(f"marker not found in CLAUDE.md: {marker!r}")
+header_end = text.index(marker) + len(marker)
+nl = text.index("\n", header_end) + 1
+# Skip the comment block right under the header
+while text[nl:nl+5] == "<!--" or text[nl:nl+1] == "<":
+    nl = text.index("\n", nl) + 1
+# Skip placeholder
+if text[nl:nl+2] == "_(":
+    nl = text.index("\n", nl) + 1
+# Insert the new line
+new_text = text[:nl] + f"- {line}\n" + text[nl:]
+p.write_text(new_text)
+print(f"appended to CLAUDE.md: {line}")
+PY
+
+git add CLAUDE.md
+git commit -m "weekly(${WEEK}): deep dive"
+git push -u origin "$BR"
+
+PR_URL=$(gh pr create \
+  --base main --head "$BR" \
+  --title "weekly: ${WEEK} deep dive" \
+  --body-file "$REPORT_FILE")
+
+printf '{"status":"ok","branch":"%s","pr":"%s","week":"%s"}\n' "$BR" "$PR_URL" "$WEEK"


### PR DESCRIPTION
Heartbeat ran 38 turns but never updated #16 — add 强制契约 telling the agent the bash is mandatory, not illustrative. Weekly hit 80-turn ceiling — extract the 10-turn git+PR ceremony into scripts/weekly-pr.sh, raise budget to 120 turns / 70 min.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/YiAgent/codesmith/EvolveCI/pr/30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated heartbeat monitoring contract requiring automatic issue reporting on probe failures and closure on success
  * Revised weekly report workflow documentation for improved automation

* **New Features**
  * Introduced automated weekly report PR creation script

* **Improvements**
  * Increased weekly job timeout from 50 to 70 minutes and maximum interactions from 80 to 120

<!-- end of auto-generated comment: release notes by coderabbit.ai -->