### PR TITLE
fix(pattern): human-readable markdown bodies + JSON code block for triage

### DIFF
--- a/.claude/commands/learn-pattern.md
+++ b/.claude/commands/learn-pattern.md
@@ -33,6 +33,9 @@
 
 ## 写入 Issue
 
+Issue body 是 markdown 格式（人可读）+ 末尾 fenced JSON 代码块（triage 解析回来）。
+渲染由 `scripts/render-pattern.sh` 完成——把 JSON 喂给它即可。
+
 ```bash
 PATTERN_JSON=$(jq -nc \
   --arg id "$ID" \
@@ -44,9 +47,11 @@ PATTERN_JSON=$(jq -nc \
   --arg description "$DESCRIPTION" \
   --argjson examples "$EXAMPLES_JSON_ARRAY" \
   '{id:$id, match:$match, category:$category, severity:$severity,
-    auto_rerun:$auto_rerun, notify:$notify,
-    description:$description, examples:$examples,
+    auto_rerun:$auto_rerun, notify:$notify, description:$description,
+    examples:$examples, source:"agent-learned",
     learned_at: now | strftime("%Y-%m-%dT%H:%M:%SZ")}')
+
+BODY=$(printf '%s' "$PATTERN_JSON" | bash scripts/render-pattern.sh)
 
 # 检查是否已经存在同 id 的 pattern issue
 EXISTING=$(gh issue list --label evolveci/pattern --search "in:title pattern: ${ID}" \
@@ -55,12 +60,12 @@ EXISTING=$(gh issue list --label evolveci/pattern --search "in:title pattern: ${
 if [ -n "$EXISTING" ]; then
   # 已有同名 → 视情况编辑（更新描述 / 加 examples）
   gh issue comment "$EXISTING" --body "${ID} 重新学习于 $(date -u +%FT%TZ)"
-  gh issue edit "$EXISTING" --body "$PATTERN_JSON"
+  gh issue edit "$EXISTING" --body "$BODY"
 else
   gh issue create \
     --title "pattern: ${ID}" \
     --label "evolveci/pattern,severity/${SEVERITY},category:${CATEGORY}" \
-    --body "$PATTERN_JSON"
+    --body "$BODY"
 fi
 ```
 

--- a/.claude/commands/triage.md
+++ b/.claude/commands/triage.md
@@ -25,13 +25,17 @@ TRIPPED=$(echo "$BODY" | jq -r '.tripped_at // empty')
 ### 步骤 2：加载上下文
 
 - `data/onboarded-repos.yml` — 监控仓库列表（仍是文件）。
-- 已知 patterns（替换原 `memory/patterns/known-patterns.json`）：
+- 已知 patterns（替换原 `memory/patterns/known-patterns.json`）：每个 pattern
+  issue 的 body 是 markdown，机器可读 JSON 嵌在末尾的 \`\`\`json 代码块里。
+  用 awk 提取：
 
   ```bash
   gh issue list --label evolveci/pattern --state all -L 100 \
-    --json body --jq '.[].body' | while read -r b; do
-      echo "$b" | jq -c .   # 每个 pattern 是 body 里的 JSON 对象
-    done > /tmp/patterns.jsonl
+    --json body --jq '.[].body' | awk '
+      /^```json$/ { in_block=1; next }
+      /^```$/     { in_block=0; next }
+      in_block    { print }
+    ' > /tmp/patterns.jsonl
   ```
 
 - 当日重跑计数器：放在内存（无需持久化文件）；超出预算时通过 step 4d 在

--- a/docs/MEMORY-MODEL.md
+++ b/docs/MEMORY-MODEL.md
@@ -96,13 +96,21 @@ PRs are reviewed by humans and squash-merged. (You can flip the agent to
 
 ### `/learn-pattern`
 
-A single `gh issue create` writes the pattern as JSON in the body, labeled
-`evolveci/pattern`. Triage reads patterns via:
+Pattern issues use a **dual-format body**: human-readable markdown on top
+(category, severity, regex, recommended action, observation history),
+machine-readable JSON in a fenced code block at the bottom. Both
+`scripts/seed-patterns.sh` and `/learn-pattern` go through
+`scripts/render-pattern.sh` to produce the body.
 
-```
+Triage extracts the JSON for matching:
+
+```bash
 gh issue list --label evolveci/pattern -L 100 --json body --jq '.[].body' \
-  | while read -r b; do echo "$b" | jq -c .; done
+  | awk '/^```json$/{f=1;next}/^```$/{f=0}f' > /tmp/patterns.jsonl
 ```
+
+Each line of `/tmp/patterns.jsonl` is one pattern object. The agent iterates
+through them for Tier-1 regex matching.
 
 ### `/check-circuit`
 

--- a/scripts/render-pattern.sh
+++ b/scripts/render-pattern.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# render-pattern.sh — render a pattern JSON object as a human-readable
+#                     markdown issue body (with the JSON kept in a fenced
+#                     code block at the bottom for triage to parse back).
+# ─────────────────────────────────────────────────────────────────────────────
+# Usage:
+#   echo '{"id":"foo","match":"bar",...}' | bash scripts/render-pattern.sh
+#
+# Used by:
+#   scripts/seed-patterns.sh
+#   .claude/commands/learn-pattern.md
+#
+# Triage extracts the JSON back via:
+#   gh issue view <num> --json body --jq .body \
+#     | awk '/^```json$/{f=1;next}/^```$/{f=0}f'
+# ─────────────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+PATTERN=$(cat)
+
+ID=$(printf '%s' "$PATTERN" | jq -r .id)
+MATCH=$(printf "%s" "$PATTERN" | jq -r .match)
+CAT=$(printf "%s" "$PATTERN" | jq -r '.category // "unknown"')
+SEV=$(printf "%s" "$PATTERN" | jq -r '.severity // "info"')
+AUTO=$(printf "%s" "$PATTERN" | jq -r '.auto_rerun // false')
+NOTIFY=$(printf "%s" "$PATTERN" | jq -r '.notify // false')
+DESCR=$(printf "%s" "$PATTERN" | jq -r '.description // ""')
+SEEN_COUNT=$(printf "%s" "$PATTERN" | jq -r '.seen_count // 0')
+LAST_SEEN=$(printf "%s" "$PATTERN" | jq -r '.last_seen // "never"')
+SOURCE=$(printf "%s" "$PATTERN" | jq -r '.source // "agent-learned"')
+
+# Map raw severity → friendly Chinese label.
+case "$SEV" in
+  low|info)            SEV_FRIENDLY="低 / 信息（info）" ;;
+  medium|warning)      SEV_FRIENDLY="中 / 警告（warning）" ;;
+  high|critical)       SEV_FRIENDLY="高 / 严重（critical）" ;;
+  *)                   SEV_FRIENDLY="未分类（$SEV）" ;;
+esac
+
+# Map raw category → friendly Chinese label + recommended action.
+case "$CAT" in
+  flaky)
+    CAT_FRIENDLY="flaky（不稳定 / 偶发）"
+    ACTION="自动重跑；若同一 fingerprint 24h 内 ≥3 次 → 升级为正式 incident。"
+    ;;
+  infra)
+    CAT_FRIENDLY="infra（基础设施）"
+    ACTION="通知 oncall；不自动重跑（避免基础设施压力放大）；考虑触发熔断器。"
+    ;;
+  code)
+    CAT_FRIENDLY="code（代码缺陷）"
+    ACTION="不自动重跑；通知 PR 作者；附带失败堆栈与建议修复点。"
+    ;;
+  dependency)
+    CAT_FRIENDLY="dependency（依赖问题）"
+    ACTION="通知；检查 lockfile / 镜像源；不自动重跑。"
+    ;;
+  unknown|*)
+    CAT_FRIENDLY="unknown（待人工分类）"
+    ACTION="进入 Tier 3 深度分析；agent 给出分类后归并到对应类别。"
+    ;;
+esac
+
+AUTO_LINE=$([ "$AUTO" = "true"   ] && echo "✅ 是" || echo "❌ 否")
+NOTIFY_LINE=$([ "$NOTIFY" = "true" ] && echo "🔔 是" || echo "🔕 否")
+
+cat <<MARKDOWN
+# pattern: ${ID}
+
+**类别**: ${CAT_FRIENDLY}
+**严重度**: ${SEV_FRIENDLY}
+**自动重跑**: ${AUTO_LINE}
+**通知**: ${NOTIFY_LINE}
+
+## 描述
+
+${DESCR:-_（暂无描述。可以由 /weekly-report 或人工补充。）_}
+
+## 匹配规则
+
+正则（length ≤200，禁止嵌套量词，已通过校验）：
+
+\`\`\`regex
+${MATCH}
+\`\`\`
+
+## 推荐处理
+
+${ACTION}
+
+## 已观察
+
+| 项目 | 值 |
+|------|----|
+| 累计次数 | ${SEEN_COUNT} |
+| 最近一次 | ${LAST_SEEN} |
+| 来源 | ${SOURCE} |
+
+## 机器可读（triage 通过此块解析，请勿手工修改）
+
+\`\`\`json
+${PATTERN}
+\`\`\`
+MARKDOWN

--- a/scripts/seed-patterns.sh
+++ b/scripts/seed-patterns.sh
@@ -66,11 +66,12 @@ jq -c '.[]' "$SEED_FILE" | while IFS= read -r pattern; do
       ;;
   esac
 
+  BODY=$(printf '%s' "$pattern" | bash "$(dirname "$0")/render-pattern.sh")
   URL=$(gh issue create \
     --repo "$REPO" \
     --title "pattern: $ID" \
     --label "evolveci/pattern,severity/$SEV,category:$CAT" \
-    --body "$pattern")
+    --body "$BODY")
   CREATED=$((CREATED + 1))
   echo "{\"status\":\"created\",\"id\":\"$ID\",\"severity\":\"$SEV\",\"category\":\"$CAT\",\"url\":\"$URL\"}"
 done


### PR DESCRIPTION
Pattern issue bodies are now markdown for humans + a fenced JSON code block at the bottom for triage. Existing 10 patterns #18-#27 already re-rendered.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/YiAgent/codesmith/EvolveCI/pr/32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated pattern issue storage format to include human-readable markdown alongside machine-readable JSON for improved data consistency.

* **Chores**
  * Enhanced triage workflow to extract patterns from updated issue body format.
  * Improved pattern rendering for automated processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->