### PR TITLE
fix(ci): point harness call at OpenCI reusable-agent.yml

### DIFF
--- a/.github/workflows/_call-harness.yml
+++ b/.github/workflows/_call-harness.yml
@@ -1,5 +1,5 @@
 # ─────────────────────────────────────────────────────────────────────────────
-# _call-harness.yml — internal reusable wrapper around OpenCI claude-harness.
+# _call-harness.yml — internal reusable wrapper around OpenCI reusable-agent.
 # ─────────────────────────────────────────────────────────────────────────────
 # DESIGN: every agent workflow in EvolveCI passes the same LLM provider, base
 # URL, secret names, permissions superset, and harness pin. Owning that
@@ -64,7 +64,7 @@ permissions:
 jobs:
   run:
     name: ${{ inputs.task }}
-    uses: YiAgent/OpenCI/.github/workflows/claude-harness.yml@main
+    uses: YiAgent/OpenCI/.github/workflows/reusable-agent.yml@main
     with:
       task:                ${{ inputs.task }}
       prompt:              ${{ inputs.prompt }}

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ EvolveCI/
 ## 与 OpenCI 的关系
 
 EvolveCI 复用 [OpenCI](https://github.com/YiAgent/OpenCI):
-- AI Agent 调用: `YiAgent/OpenCI/.github/workflows/claude-harness.yml@main`
+- AI Agent 调用: `YiAgent/OpenCI/.github/workflows/reusable-agent.yml@main`
 - Slack 通知: `YiAgent/OpenCI/actions/integrations/slack-notify@v2`
 
 OpenCI 关心**应用**的健康度；EvolveCI 关心**流水线**的健康度。

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -43,7 +43,7 @@ to **all four** agents at once.
 | GitHub token (cross-repo) | `secrets.CROSS_REPO_PAT` then `secrets.GITHUB_TOKEN` | falls back automatically | Set `CROSS_REPO_PAT` only when monitored repos live outside this org. |
 | Slack webhook | `secrets.SLACK_CI_WEBHOOK` | unset (alerts go silent) | Set to receive Slack alerts. |
 | Permissions superset | hard-coded | `contents:write, issues:write, pull-requests:write, actions:read, id-token:write` | Only edit when the harness reusable workflow's permission requirements change. |
-| Harness pin | `YiAgent/OpenCI/.github/workflows/claude-harness.yml@main` | tracks main | Pin to a SHA when you want a frozen contract. |
+| Harness pin | `YiAgent/OpenCI/.github/workflows/reusable-agent.yml@main` | tracks main | Pin to a SHA when you want a frozen contract. |
 
 ---
 


### PR DESCRIPTION
## Summary

- OpenCI renamed `claude-harness.yml` → `reusable-agent.yml`, so every `agent-*` workflow currently fails when GitHub resolves the `workflow_call` target (404 on the reusable workflow).
- Update `_call-harness.yml` to call `YiAgent/OpenCI/.github/workflows/reusable-agent.yml@main`. Inputs and secrets are byte-compatible with the old harness — no caller changes required.
- Refresh the two user-facing doc references (`README.md`, `docs/CONFIG.md`) so the documented harness path matches reality.

## Why this is minimal

The new reusable workflow (verified against `YiAgent/OpenCI@main`) declares the same required inputs (`task`, plus the optional `prompt` / `prompt-path` / `context` / `model` / `max-turns` / `timeout-minutes` / `extra-allowed-tools` / `api-provider`) and the same secrets (`api-key`, `api-base-url`, `github-token`, `slack-webhook`). The wrapper passes exactly those, so renaming the file is sufficient.

`docs/SPEC.md` still uses the old `claude-harness` name in historical/architecture prose — left untouched to keep this PR focused on the failure cause.

## Test plan

- [ ] Manually dispatch `Agent — CI Heartbeat` from the Actions tab on this branch and confirm the `workflow_call` resolves and the harness job starts.
- [ ] Manually dispatch `Agent — CI Triage` and confirm the collect → triage chain runs end-to-end.
- [ ] Wait for the next scheduled `agent-daily.yml` / `agent-weekly.yml` after merge and confirm they no longer 404.

https://claude.ai/code/session_01LDsZDczUFYswGdVL5QqTNP

---
_Generated by [Claude Code](https://claude.ai/code/session_01LDsZDczUFYswGdVL5QqTNP)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/YiAgent/codesmith/EvolveCI/pr/46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow harness references across repository configuration files

* **Documentation**
  * Updated configuration guides and integration documentation to reflect current workflow harness references

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/YiAgent/EvolveCI/pull/46)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->